### PR TITLE
🔒️ Set JsonSerializerSettings' MaxDepth property to 128 & remove unused ComparisonMessage's utily methods and classes

### DIFF
--- a/src/Criteo.OpenApi.Comparator/ComparisonMessage.cs
+++ b/src/Criteo.OpenApi.Comparator/ComparisonMessage.cs
@@ -3,7 +3,6 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Criteo.OpenApi.Comparator.Parser;
@@ -127,47 +126,9 @@ namespace Criteo.OpenApi.Comparator
         public string NewLocation() => Location(NewDocument, NewJson());
 
         /// <summary>
-        /// Converts JSON object into a serialized JSON string
-        /// </summary>
-        /// <returns>JSON as string</returns>
-        public string GetValidationMessagesAsJson()
-        {
-            var rawMessage = new JsonComparisonMessage
-            {
-                Id = Id.ToString(),
-                Code = Code,
-                Message = Message,
-                Type = Severity.ToString(),
-                DocUrl = DocUrl,
-                Mode = Mode.ToString(),
-                Old = new JsonLocation { Ref = OldJsonRef, Path = OldJson()?.Path, Location = OldLocation(), },
-                New = new JsonLocation { Ref = NewJsonRef, Path = NewJson()?.Path, Location = NewLocation(), }
-            };
-
-            return JsonConvert.SerializeObject(
-                rawMessage,
-                Formatting.Indented,
-                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }
-            );
-        }
-
-        /// <summary>
         /// Converts the currents ComparisonMessage object into a string message
         /// </summary>
         public override string ToString() =>
             $"code = {Code}, type = {Severity}, message = {Message}, docurl = {DocUrl}, mode = {Mode}";
-    }
-
-    public class CustomComparer : IEqualityComparer<ComparisonMessage>
-    {
-        /// <summary>
-        /// Compares two comparison messages
-        /// </summary>
-        public bool Equals(ComparisonMessage message1, ComparisonMessage message2) =>
-            message1?.Message == message2?.Message;
-
-        /// <param name="comparison">ComparisonMessage</param>
-        /// <returns>The hash code of a ComparisonMessage object</returns>
-        public int GetHashCode(ComparisonMessage comparison) => comparison.Message.GetHashCode();
     }
 }

--- a/src/Criteo.OpenApi.Comparator/Parser/OpenApiParser.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/OpenApiParser.cs
@@ -19,6 +19,7 @@ namespace Criteo.OpenApi.Comparator.Parser
         {
             var settings = new JsonSerializerSettings
             {
+                MaxDepth = 128,
                 TypeNameHandling = TypeNameHandling.None,
                 MetadataPropertyHandling = MetadataPropertyHandling.Ignore
             };

--- a/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using Microsoft.OpenApi.Models;
 
-namespace Criteo.OpenApi.Comparator
+namespace Criteo.OpenApi.Comparator.Parser
 {
     public abstract class SwaggerJsonConverter : JsonConverter
     {
@@ -29,6 +29,7 @@ namespace Criteo.OpenApi.Comparator
 
             var settings = new JsonSerializerSettings
             {
+                MaxDepth = 128,
                 TypeNameHandling = TypeNameHandling.None,
                 MetadataPropertyHandling = MetadataPropertyHandling.Ignore
             };


### PR DESCRIPTION
NewtonSoft.Json package version < 13.0.1 exposes our apps to DoS attacks, this could be avoided by either upgrading the package or limiting the json max depth to 128