### PR TITLE
♻️ Component compare

### DIFF
--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/old/response_body_format_now_supported.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/old/response_body_format_now_supported.json
@@ -36,7 +36,7 @@
             }
           },
           "404": {
-            "$ref": "#/components/schemas/Pet"
+            "$ref": "#/components/responses/ErrorResponse"
           }
         }
       }

--- a/src/Criteo.OpenApi.Comparator/Comparators/ComponentComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ComponentComparator.cs
@@ -1,69 +1,20 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
 using System;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Criteo.OpenApi.Comparator.Comparators
 {
-    /// <summary>
-    /// Compare the fields that components have in common (e.g. the $ref field)
-    /// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#componentsObject
-    /// </summary>
-    internal abstract class ComponentComparator
+    internal static class ComponentComparator<T> where T : IOpenApiReferenceable
     {
-        /// <summary>
-        /// Compare a modified parameter to an old one and look for breaking as well as non-breaking changes.
-        /// </summary>
-        /// <param name="context">The modified document context.</param>
-        /// <param name="oldParameter">The original parameter to compare.</param>
-        /// <param name="newParameter">The new parameter to compare.</param>
-        /// <returns>A list of messages from the comparison.</returns>
-        protected void Compare(ComparisonContext context, OpenApiParameter oldParameter, OpenApiParameter newParameter)
+        internal static void Compare(ComparisonContext context, T oldComponent, T newComponent)
         {
-            if (oldParameter == null)
-                throw new ArgumentNullException(nameof(oldParameter));
+            if (oldComponent == null)
+                throw new ArgumentNullException(nameof(oldComponent));
 
-            if (newParameter == null)
-                throw new ArgumentNullException(nameof(newParameter));
+            if (newComponent == null)
+                throw new ArgumentNullException(nameof(newComponent));
 
-            CompareReference(context, oldParameter.Reference, newParameter.Reference);
-        }
-
-        /// <summary>
-        /// Compare a modified response to an old one and look for breaking as well as non-breaking changes.
-        /// </summary>
-        /// <param name="context">The modified document context.</param>
-        /// <param name="oldResponse">The original response to compare.</param>
-        /// <param name="newResponse">The new response to compare.</param>
-        /// <returns>A list of messages from the comparison.</returns>
-        protected void Compare(ComparisonContext context, OpenApiResponse oldResponse, OpenApiResponse newResponse)
-        {
-            if (oldResponse == null)
-                throw new ArgumentNullException(nameof(oldResponse));
-
-            if (newResponse == null)
-                throw new ArgumentNullException(nameof(newResponse));
-
-            CompareReference(context, oldResponse.Reference, newResponse.Reference);
-        }
-
-        /// <summary>
-        /// Compare a modified header to an old one and look for breaking as well as non-breaking changes.
-        /// </summary>
-        /// <param name="context">The modified document context.</param>
-        /// <param name="oldHeader">The original header to compare.</param>
-        /// <param name="newHeader">The new header to compare.</param>
-        /// <returns>A list of messages from the comparison.</returns>
-        protected void Compare(ComparisonContext context, OpenApiHeader oldHeader, OpenApiHeader newHeader)
-        {
-            if (oldHeader == null)
-                throw new ArgumentNullException(nameof(oldHeader));
-
-            if (newHeader == null)
-                throw new ArgumentNullException(nameof(newHeader));
-
-            CompareReference(context, oldHeader.Reference, newHeader.Reference);
+            CompareReference(context, oldComponent.Reference, newComponent.Reference);
         }
 
         private static void CompareReference(ComparisonContext context,

--- a/src/Criteo.OpenApi.Comparator/Comparators/ContentComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ContentComparator.cs
@@ -14,7 +14,8 @@ namespace Criteo.OpenApi.Comparator.Comparators
         }
 
         internal void Compare(ComparisonContext context,
-            IDictionary<string, OpenApiMediaType> oldContent, IDictionary<string, OpenApiMediaType> newContent)
+            IDictionary<string, OpenApiMediaType> oldContent, 
+            IDictionary<string, OpenApiMediaType> newContent)
         {
             oldContent = oldContent ?? new Dictionary<string, OpenApiMediaType>();
             newContent = newContent ?? new Dictionary<string, OpenApiMediaType>();

--- a/src/Criteo.OpenApi.Comparator/Comparators/ParameterComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ParameterComparator.cs
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Criteo.OpenApi.Comparator.Comparators.Extensions;
 using Microsoft.OpenApi.Models;
 
 namespace Criteo.OpenApi.Comparator.Comparators
 {
-    internal class ParameterComparator : ComponentComparator
+    internal class ParameterComparator
     {
         private readonly SchemaComparator _schemaComparator;
         private readonly ContentComparator _contentComparator;
@@ -27,15 +26,9 @@ namespace Criteo.OpenApi.Comparator.Comparators
             OpenApiParameter oldParameter,
             OpenApiParameter newParameter)
         {
-            if (oldParameter == null)
-                throw new ArgumentNullException(nameof(oldParameter));
-
-            if (newParameter == null)
-                throw new ArgumentNullException(nameof(newParameter));
+            ComponentComparator<OpenApiParameter>.Compare(context, oldParameter, newParameter);
 
             context.Direction = DataDirection.Request;
-
-            base.Compare(context, oldParameter, newParameter);
 
             var areParametersReferenced = false;
 

--- a/src/Criteo.OpenApi.Comparator/Comparators/ResponseComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ResponseComparator.cs
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Criteo.OpenApi.Comparator.Comparators.Extensions;
 using Microsoft.OpenApi.Models;
 
 namespace Criteo.OpenApi.Comparator.Comparators
 {
-    internal class ResponseComparator : ComponentComparator
+    internal class ResponseComparator
     {
         private readonly ContentComparator _contentComparator;
 
@@ -20,11 +19,7 @@ namespace Criteo.OpenApi.Comparator.Comparators
         internal void Compare(ComparisonContext context,
             OpenApiResponse oldResponse, OpenApiResponse newResponse)
         {
-            if (oldResponse == null)
-                throw new ArgumentNullException(nameof(oldResponse));
-
-            if (newResponse == null)
-                throw new ArgumentNullException(nameof(newResponse));
+            ComponentComparator<OpenApiResponse>.Compare(context, oldResponse, newResponse);
 
             context.Direction = DataDirection.Response;
 
@@ -43,8 +38,6 @@ namespace Criteo.OpenApi.Comparator.Comparators
             }
 
             CompareHeaders(context, oldResponse.Headers, newResponse.Headers);
-
-            base.Compare(context, oldResponse, newResponse);
 
             _contentComparator.Compare(context, oldResponse.Content, newResponse.Content);
 
@@ -68,7 +61,7 @@ namespace Criteo.OpenApi.Comparator.Comparators
                 }
                 else
                 {
-                    base.Compare(context, oldHeader, header.Value);
+                    ComponentComparator<OpenApiHeader>.Compare(context, oldHeader, header.Value);
                 }
                 context.Pop();
             }


### PR DESCRIPTION
⚠️ Should not be merged before #12, #13 and #14  ⚠️ 

ComponentCompare's Compare method was hidden by inheriting classes (ResponseCompare, etc.). Such a class is actually more useful as a Utility.