### PR TITLE
Allow directly comparing files from their (remote) URLs.

### DIFF
--- a/src/Criteo.OpenApi.Comparator.Cli/Options.cs
+++ b/src/Criteo.OpenApi.Comparator.Cli/Options.cs
@@ -13,13 +13,13 @@ namespace Criteo.OpenApi.Comparator.Cli
         /// <summary>
         /// Path to old OpenAPI Specification
         /// </summary>
-        [Option('o', "old", Required = true, HelpText = "Path to old OpenAPI Specification.")]
+        [Option('o', "old", Required = true, HelpText = "Path or URL to old OpenAPI Specification.")]
         public string OldSpec { get; set; }
-        
+
         /// <summary>
         /// Path to new OpenAPI Specification
         /// </summary>
-        [Option('n', "new", Required = true, HelpText = "Path to new OpenAPI Specification.")]
+        [Option('n', "new", Required = true, HelpText = "Path or URL to new OpenAPI Specification.")]
         public string NewSpec { get; set; }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Criteo.OpenApi.Comparator.Cli
         /// Ideal for deserialization
         /// </summary>
         Json = 0,
-        
+
         /// <summary>
         /// Ideal for human reading (<see cref="ComparisonMessage.ToString"/>)
         /// </summary>

--- a/src/Criteo.OpenApi.Comparator.Cli/Program.cs
+++ b/src/Criteo.OpenApi.Comparator.Cli/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 
 namespace Criteo.OpenApi.Comparator.Cli
@@ -25,7 +26,7 @@ namespace Criteo.OpenApi.Comparator.Cli
             {
                 return 1;
             }
-            
+
             var options = parserResult.Value;
 
             var oldFileFound = TryReadFile(options.OldSpec, out var oldOpenApiSpecification);
@@ -36,15 +37,37 @@ namespace Criteo.OpenApi.Comparator.Cli
                 Console.WriteLine("Exiting.");
                 return 1;
             }
-            
+
             var differences = OpenApiComparator.Compare(oldOpenApiSpecification, newOpenApiSpecification);
 
             DisplayOutput(differences, options.OutputFormat);
-            
+
             return 0;
         }
 
         private static bool TryReadFile(string path, out string fileContent)
+        {
+            try
+            {
+                var uri = new Uri(path);
+                if (uri.IsFile)
+                {
+                    return TryReadLocalFile(path, out fileContent);
+                }
+                else
+                {
+                    return TryReadRemoteFile(path, out fileContent);
+                }
+            }
+            catch (UriFormatException)
+            {
+                Console.WriteLine($"Failed to interpret the provided URI: {path}.");
+                fileContent = null;
+            }
+            return false;
+        }
+
+        private static bool TryReadLocalFile(string path, out string fileContent)
         {
             try
             {
@@ -57,6 +80,33 @@ namespace Criteo.OpenApi.Comparator.Cli
                 fileContent = null;
                 return false;
             }
+        }
+
+        private static bool TryReadRemoteFile(string path, out string fileContent)
+        {
+            try
+            {
+                using var client = new HttpClient();
+                fileContent = client.GetStringAsync(path).Result;
+                return true;
+            }
+            catch (HttpRequestException exception)
+            {
+                Console.WriteLine($"Http request failed on {path}: {exception.Message}");
+            }
+            catch (AggregateException exception)
+            {
+                var stringWriter = new StringWriter();
+                stringWriter.WriteLine($"Exception caught while waiting for the Http request result from {path}:");
+                exception.Handle((innerException) =>
+                {
+                    stringWriter.Write($"- {innerException.GetType()}: {exception.Message}");
+                    return true;
+                });
+                Console.WriteLine(stringWriter.ToString());
+            }
+            fileContent = null;
+            return false;
         }
 
         private static void DisplayOutput(IEnumerable<ComparisonMessage> differences, OutputFormat outputFormat)


### PR DESCRIPTION
This answers request: https://github.com/criteo/openapi-comparator/issues/24