### PR TITLE
chore!: target current .NET LTS, upgrade Newtonsoft.Json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,9 @@ jobs:
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: | 
-            3.x
-            5.x
+          dotnet-version: |
             6.x
+            8.x
       - name: Publish Criteo.OpenApi.Comparator to NuGet
         id: publish_package_nuget
         uses: brandedoutcast/publish-nuget@v2

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -10,10 +10,9 @@ jobs:
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: | 
-            3.x
-            5.x
+          dotnet-version: |
             6.x
+            8.x
       - name: Publish Criteo.OpenApi.Comparator.Cli to NuGet
         id: publish_cli_nuget
         uses: brandedoutcast/publish-nuget@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ jobs:
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.x
+          dotnet-version: |
+            6.x
+            8.x
       - name: Install dependencies
         run: dotnet restore ./src/Criteo.OpenApi.Comparator.UTest
       - name: Build

--- a/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
+++ b/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3;net5;net6;</TargetFrameworks>
+        <TargetFrameworks>net6;net8;</TargetFrameworks>
         <LangVersion>Latest</LangVersion>
         <OutputType>Exe</OutputType>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/Criteo.OpenApi.Comparator.UTest/Criteo.OpenApi.Comparator.UTest.csproj
+++ b/src/Criteo.OpenApi.Comparator.UTest/Criteo.OpenApi.Comparator.UTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFrameworks>net6;net8;</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Criteo.OpenApi.Comparator.UTest</RootNamespace>
     <NoWarn>1591</NoWarn>

--- a/src/Criteo.OpenApi.Comparator/Criteo.OpenApi.Comparator.csproj
+++ b/src/Criteo.OpenApi.Comparator/Criteo.OpenApi.Comparator.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">


### PR DESCRIPTION
- Set TargetFrameworks to .NET 6 and .NET 8
- Upgrade Newtonsoft.Json to 13.0.1 (fix CVE-2024-21907)

BREAKING CHANGE: drop .NET Core 3 and .NET 5 support