### PR TITLE
fix: comparison after schema reference change

### DIFF
--- a/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
+++ b/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
@@ -29,6 +29,7 @@ public class OpenApiSpecificationsCompareTests
 {
     private static readonly JsonSerializerOptions serializerOptions = new()
     {
+        WriteIndented = true,
         Converters = { new JsonStringEnumConverter() }
     };
 
@@ -43,11 +44,13 @@ public class OpenApiSpecificationsCompareTests
         var differences = OpenApiComparator
             .Compare(File.ReadAllText(oldFileName), File.ReadAllText(newFileName));
 
+        var expectedDifferencesText = File.ReadAllText(diffFileName);
         var expectedDifferences = JsonSerializer
-            .Deserialize<ComparisonMessageModel[]>(File.ReadAllText(diffFileName), serializerOptions);
+            .Deserialize<ComparisonMessageModel[]>(expectedDifferencesText, serializerOptions);
 
         Assert.That(differences,
-            Is.EquivalentTo(expectedDifferences).Using<ComparisonMessage, ComparisonMessageModel>(Comparer));
+            Is.EquivalentTo(expectedDifferences).Using<ComparisonMessage, ComparisonMessageModel>(Comparer),
+            $"Expected differences:\n{expectedDifferencesText}\nActual differences:\n{JsonSerializer.Serialize(differences, serializerOptions)}");
     }
 
     private static IEnumerable<string> TestCases()

--- a/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
+++ b/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
@@ -75,6 +75,8 @@ public class OpenApiSpecificationsCompareTests
             && message.Message == model.Message
             && message.OldJsonRef == model.OldJsonRef
             && message.NewJsonRef == model.NewJsonRef
+            && message.OldJsonPath == model.OldJsonPath
+            && message.NewJsonPath == model.NewJsonPath
             && message.Id == model.Id
             && message.Code == model.Code
             && message.Mode == model.Mode;
@@ -87,6 +89,8 @@ internal class ComparisonMessageModel
     public string Message { get; set; }
     public string OldJsonRef { get; set; }
     public string NewJsonRef { get; set; }
+    public string OldJsonPath { get; set; }
+    public string NewJsonPath { get; set; }
     public int Id { get; set; }
     public string Code { get; set; }
     public MessageType Mode { get; set; }

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
+    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "Id": 1021,
     "Code": "AddedAdditionalProperties",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/schemas/Pet/additionalProperties",
+    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "Id": 1021,
     "Code": "AddedAdditionalProperties",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
+    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1021,
     "Code": "AddedAdditionalProperties",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
     "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
     "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1021,
     "Code": "AddedAdditionalProperties",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -38,8 +38,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -47,8 +47,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/properties/accountType/enum",
-    "NewJsonRef": "#/schemas/Pet/properties/accountType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -31,6 +37,8 @@
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -40,6 +48,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -49,6 +59,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
     "NewJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_header/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_header/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version adds a required header \u0027x-d\u0027.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
+    "OldJsonPath": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
+    "NewJsonPath": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
     "Id": 1013,
     "Code": "AddingHeader",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version adds a required header \u0027x-c\u0027.",
     "OldJsonRef": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
     "NewJsonRef": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
+    "OldJsonPath": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
+    "NewJsonPath": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
     "Id": 1013,
     "Code": "AddingHeader",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_operation/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_operation/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding an operation that was not found in the old version.",
     "OldJsonRef": "#/paths/~1api~1Paths/post",
     "NewJsonRef": "#/paths/~1api~1Paths/post",
+    "OldJsonPath": "#/paths/~1api~1Paths/post",
+    "NewJsonPath": "#/paths/~1api~1Paths/post",
     "Id": 1039,
     "Code": "AddedOperation",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version is adding an operation that was not found in the old version.",
     "OldJsonRef": "#/paths/~1api~1Operations/head",
     "NewJsonRef": "#/paths/~1api~1Operations/head",
+    "OldJsonPath": "#/paths/~1api~1Operations/head",
+    "NewJsonPath": "#/paths/~1api~1Operations/head",
     "Id": 1039,
     "Code": "AddedOperation",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_parameter/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_parameter/diff.json
@@ -4,6 +4,8 @@
     "Message": "The optional parameter \u0027limitParam\u0027 was added in the new version.",
     "OldJsonRef": null,
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1",
+    "OldJsonPath": null,
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/parameters/1",
     "Id": 1043,
     "Code": "AddingOptionalParameter",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_property/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new optional property \u0027message\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/components/parameters/skipParam/schema/properties/message",
-    "NewJsonRef": "#/components/parameters/skipParam/schema/properties/message",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/properties/message",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/properties/message",
+    "OldJsonPath": "#/components/parameters/skipParam/schema/properties/message",
+    "NewJsonPath": "#/components/parameters/skipParam/schema/properties/message",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new optional property \u0027end\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/components/parameters/limitParam/schema/properties/end",
-    "NewJsonRef": "#/components/parameters/limitParam/schema/properties/end",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/end",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/end",
+    "OldJsonPath": "#/components/parameters/limitParam/schema/properties/end",
+    "NewJsonPath": "#/components/parameters/limitParam/schema/properties/end",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_optional_property/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new optional property \u0027message\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/properties/message",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/properties/message",
+    "OldJsonRef": "#/components/parameters/skipParam/schema/properties/message",
+    "NewJsonRef": "#/components/parameters/skipParam/schema/properties/message",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new optional property \u0027end\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/end",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/end",
+    "OldJsonRef": "#/components/parameters/limitParam/schema/properties/end",
+    "NewJsonRef": "#/components/parameters/limitParam/schema/properties/end",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_path/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_path/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding a path that was not found in the old version.",
     "OldJsonRef": null,
     "NewJsonRef": "#/paths/~1api~1Paths",
+    "OldJsonPath": null,
+    "NewJsonPath": "#/paths/~1api~1Paths",
     "Id": 1038,
     "Code": "AddedPath",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_property_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_property_in_response/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027petType\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027petAge\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petAge",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petAge",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petAge",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petAge",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petAge",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petAge",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"
@@ -22,6 +26,8 @@
     "Message": "The new version has a new property \u0027message\u0027 in response that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027message\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
-    "NewJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "OldJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "NewJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "OldJsonPath": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "NewJsonPath": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_property_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_property_in_response/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027petType\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027petAge\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petAge",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petAge",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petAge",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petAge",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new property \u0027message\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
-    "NewJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "OldJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "NewJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
     "Id": 1041,
     "Code": "AddedPropertyInResponse",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_readOnly_property_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_readOnly_property_in_response/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a new read-only property \u0027petType\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType",
     "Id": 1040,
     "Code": "AddedReadOnlyPropertyInResponse",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has a new read-only property \u0027message\u0027 in response that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "Id": 1040,
     "Code": "AddedReadOnlyPropertyInResponse",
     "Mode": "Addition"
@@ -20,8 +24,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a new read-only property \u0027message\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
-    "NewJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "OldJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "NewJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "OldJsonPath": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "NewJsonPath": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
     "Id": 1040,
     "Code": "AddedReadOnlyPropertyInResponse",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_readOnly_property_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_readOnly_property_in_response/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a new read-only property \u0027petType\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
     "Id": 1040,
     "Code": "AddedReadOnlyPropertyInResponse",
     "Mode": "Addition"
@@ -20,8 +20,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a new read-only property \u0027message\u0027 in response that was not found in the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
-    "NewJsonRef": "#/paths/~1pets/get/responses/500/content/application~1json/schema/properties/message",
+    "OldJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
+    "NewJsonRef": "#/components/responses/InternalErrorResponse/content/application~1json/schema/properties/message",
     "Id": 1040,
     "Code": "AddedReadOnlyPropertyInResponse",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_request_body/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_request_body/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding a requestBody that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/post/requestBody",
     "NewJsonRef": "#/paths/~1pets/post/requestBody",
+    "OldJsonPath": "#/paths/~1pets/post/requestBody",
+    "NewJsonPath": "#/paths/~1pets/post/requestBody",
     "Id": 1046,
     "Code": "AddedRequestBody",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_parameter/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_parameter/diff.json
@@ -4,6 +4,8 @@
     "Message": "The required parameter \u0027limitParam\u0027 was added in the new version.",
     "OldJsonRef": null,
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1",
+    "OldJsonPath": null,
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/parameters/1",
     "Id": 1010,
     "Code": "AddingRequiredParameter",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has new required property \u0027petType\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/schemas/Pet",
-    "NewJsonRef": "#/schemas/Pet",
+    "OldJsonRef": "#/components/schemas/Pet",
+    "NewJsonRef": "#/components/schemas/Pet",
     "Id": 1034,
     "Code": "AddedRequiredProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version has new required property \u0027petType\u0027 that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
     "Id": 1034,
     "Code": "AddedRequiredProperty",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has new required property \u0027message\u0027 that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
     "Id": 1034,
     "Code": "AddedRequiredProperty",
     "Mode": "Addition"
@@ -22,6 +26,8 @@
     "Message": "The new version has new required property \u0027petType\u0027 that was not found in the old version.",
     "OldJsonRef": "#/components/schemas/Pet",
     "NewJsonRef": "#/components/schemas/Pet",
+    "OldJsonPath": "#/components/schemas/Pet",
+    "NewJsonPath": "#/components/schemas/Pet",
     "Id": 1034,
     "Code": "AddedRequiredProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_response_code/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_response_code/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version adds a response code \u0027200\u0027.",
     "OldJsonRef": "#/paths/~1api~1Operations/post/responses/200",
     "NewJsonRef": "#/paths/~1api~1Operations/post/responses/200",
+    "OldJsonPath": "#/paths/~1api~1Operations/post/responses/200",
+    "NewJsonPath": "#/paths/~1api~1Operations/post/responses/200",
     "Id": 1011,
     "Code": "AddingResponseCode",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version adds a response code \u0027202\u0027.",
     "OldJsonRef": "#/paths/~1api~1Responses/get/responses/202",
     "NewJsonRef": "#/paths/~1api~1Responses/get/responses/202",
+    "OldJsonPath": "#/paths/~1api~1Responses/get/responses/202",
+    "NewJsonPath": "#/paths/~1api~1Responses/get/responses/202",
     "Id": 1011,
     "Code": "AddingResponseCode",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_schema_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_schema_in_response/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding a new schema that was not found in the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
     "Id": 1048,
     "Code": "AddedSchema",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/changed_parameter_order/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/changed_parameter_order/diff.json
@@ -4,6 +4,8 @@
     "Message": "The order of parameter \u0027skipParam\u0027 was changed. ",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters",
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/parameters",
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/parameters",
     "Id": 1042,
     "Code": "ChangedParameterOrder",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The order of parameter \u0027limitParam\u0027 was changed. ",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters",
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/parameters",
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/parameters",
     "Id": 1042,
     "Code": "ChangedParameterOrder",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The \u0027constant\u0027 status changed from the old version to the new.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/enum",
+    "OldJsonRef": "#/components/parameters/limitParam/enum",
+    "NewJsonRef": "#/components/parameters/limitParam/enum",
     "Id": 1016,
     "Code": "ConstantStatusHasChanged",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString, Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -20,8 +20,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The \u0027constant\u0027 status changed from the old version to the new.",
-    "OldJsonRef": "#/components/parameters/limitParam/enum",
-    "NewJsonRef": "#/components/parameters/limitParam/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/enum",
+    "OldJsonPath": "#/components/parameters/limitParam/enum",
+    "NewJsonPath": "#/components/parameters/limitParam/enum",
     "Id": 1016,
     "Code": "ConstantStatusHasChanged",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString, Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
-    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "OldJsonPath": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonPath": "#/components/parameters/limitParam/schema/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -20,8 +24,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
-    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
+    "OldJsonPath": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonPath": "#/components/parameters/limitParam/schema/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027pattern\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/accessKey/pattern",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/accessKey/pattern",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/accessKey/pattern",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/accessKey/pattern",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027uniqueItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/uniqueItems",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/uniqueItems",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -38,8 +38,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a different \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027pattern\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/accessKey/pattern",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/accessKey/pattern",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/accessKey/pattern",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/accessKey/pattern",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/accessKey/pattern",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/accessKey/pattern",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027uniqueItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/uniqueItems",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/uniqueItems",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/uniqueItems",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -38,8 +46,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a different \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"
@@ -49,6 +59,8 @@
     "Message": "The new version has a different \u0027multipleOf\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/maxRequest/multipleOf",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/maxRequest/multipleOf",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/maxRequest/multipleOf",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/maxRequest/multipleOf",
     "Id": 1036,
     "Code": "ConstraintChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maximum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minimum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maxLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -38,8 +38,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maxItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -47,8 +47,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maximum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/minLimit/maximum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minimum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maxLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/minTextSize/minLength",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -38,8 +46,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027maxItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -47,8 +57,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a more constraining \u0027minItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -58,6 +70,8 @@
     "Message": "The new version has a more constraining \u0027maximum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -67,6 +81,8 @@
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -76,6 +92,8 @@
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maximum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/minLimit/maximum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minimum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maxLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -29,8 +35,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/minTextSize/minLength",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -38,8 +46,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maxItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -47,8 +57,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -56,8 +68,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -65,8 +79,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
-    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -76,6 +92,8 @@
     "Message": "The new version has a less constraining \u0027maximum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/code/maximum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maximum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minLimit/maximum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/minLimit/maximum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minimum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/exclusiveMin/minimum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/exclusiveMin/minimum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maxLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/maxTextSize/maxLength",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/maxTextSize/maxLength",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minLength\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/minTextSize/minLength",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/minTextSize/minLength",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -38,8 +38,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027maxItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/maxItems",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/maxItems",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -47,8 +47,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027minItems\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/redirectUrl/minItems",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/redirectUrl/minItems",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -56,8 +56,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -65,8 +65,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
+    "OldJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
+    "NewJsonRef": "#/components/schemas/limitParam/properties/constrainsItems/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different default value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/default",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/default",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/default",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/default",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/default",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/default",
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version has a different default value than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/default",
     "NewJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/default",
+    "OldJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/default",
+    "NewJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/default",
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version has a different default value than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/properties/name/default",
     "NewJsonRef": "#/components/schemas/Pet/properties/name/default",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/default",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/default",
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different default value than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/default",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/default",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/default",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/default",
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different default value than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/properties/name/default",
-    "NewJsonRef": "#/schemas/Pet/properties/name/default",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/default",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/default",
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/different_allOf/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/different_allOf/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/allOf",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/allOf",
+    "OldJsonRef": "#/components/parameters/petParam/schema/allOf",
+    "NewJsonRef": "#/components/parameters/petParam/schema/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
-    "OldJsonRef": "#/schemas/Cat/allOf",
-    "NewJsonRef": "#/schemas/Cat/allOf",
+    "OldJsonRef": "#/components/schemas/Cat/allOf",
+    "NewJsonRef": "#/components/schemas/Cat/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/different_allOf/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/different_allOf/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
-    "OldJsonRef": "#/components/parameters/petParam/schema/allOf",
-    "NewJsonRef": "#/components/parameters/petParam/schema/allOf",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/allOf",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/allOf",
+    "OldJsonPath": "#/components/parameters/petParam/schema/allOf",
+    "NewJsonPath": "#/components/parameters/petParam/schema/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/allOf",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/allOf",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/allOf",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
     "OldJsonRef": "#/components/schemas/Cat/allOf",
     "NewJsonRef": "#/components/schemas/Cat/allOf",
+    "OldJsonPath": "#/components/schemas/Cat/allOf",
+    "NewJsonPath": "#/components/schemas/Cat/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/discriminator",
-    "NewJsonRef": "#/components/schemas/Pet/discriminator",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/discriminator",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/discriminator",
+    "OldJsonPath": "#/components/schemas/Pet/discriminator",
+    "NewJsonPath": "#/components/schemas/Pet/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version has a different discriminator than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/201/content/application~1json/schema/discriminator",
     "NewJsonRef": "#/paths/~1pets/get/responses/201/content/application~1json/schema/discriminator",
+    "OldJsonPath": "#/paths/~1pets/get/responses/201/content/application~1json/schema/discriminator",
+    "NewJsonPath": "#/paths/~1pets/get/responses/201/content/application~1json/schema/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version has a different discriminator than the previous one.",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/discriminator",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/discriminator",
+    "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/discriminator",
+    "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -31,6 +37,8 @@
     "Message": "The new version has a different discriminator than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/discriminator",
     "NewJsonRef": "#/components/schemas/Pet/discriminator",
+    "OldJsonPath": "#/components/schemas/Pet/discriminator",
+    "NewJsonPath": "#/components/schemas/Pet/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/discriminator",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/discriminator",
+    "OldJsonRef": "#/components/schemas/Pet/discriminator",
+    "NewJsonRef": "#/components/schemas/Pet/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/discriminator",
-    "NewJsonRef": "#/schemas/Pet/discriminator",
+    "OldJsonRef": "#/components/schemas/Pet/discriminator",
+    "NewJsonRef": "#/components/schemas/Pet/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_add/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_remove/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -29,8 +35,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -29,8 +29,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +29,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +35,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestResponseEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestResponseEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
+    "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestResponseEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_add/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_remove/diff.json
@@ -4,6 +4,8 @@
     "Message": "The \u0027constant\u0027 status changed from the old version to the new.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/0/enum",
     "Id": 1016,
     "Code": "ConstantStatusHasChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -22,6 +26,8 @@
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_add/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_remove/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/RequestOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/RequestOnlyEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_add/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1020,
     "Code": "AddedEnumValue",
     "Mode": "Addition"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1037,
     "Code": "ConstraintIsWeaker",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
-    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
-    "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
+    "NewJsonRef": "#/components/schemas/ResponseOnlyEnum/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_remove/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
+    "NewJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/long_running_operation/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/long_running_operation/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version has a different \u0027x-ms-long-running-operation\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/x-ms-long-running-operation",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/x-ms-long-running-operation",
+    "OldJsonPath": "#/paths/~1api~1Parameters/get/x-ms-long-running-operation",
+    "NewJsonPath": "#/paths/~1api~1Parameters/get/x-ms-long-running-operation",
     "Id": 1044,
     "Code": "LongRunningOperationExtensionChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version has a different \u0027x-ms-long-running-operation\u0027 value than the previous one.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/x-ms-long-running-operation",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/x-ms-long-running-operation",
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/x-ms-long-running-operation",
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/x-ms-long-running-operation",
     "Id": 1044,
     "Code": "LongRunningOperationExtensionChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/modified_operation_id/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/modified_operation_id/diff.json
@@ -4,6 +4,8 @@
     "Message": "The operation id has been changed from \u0027Paths_Get\u0027 to \u0027Paths_List\u0027. This will impact generated code.",
     "OldJsonRef": "#/paths/~1api~1Paths/get/operationId",
     "NewJsonRef": "#/paths/~1api~1Paths/get/operationId",
+    "OldJsonPath": "#/paths/~1api~1Paths/get/operationId",
+    "NewJsonPath": "#/paths/~1api~1Paths/get/operationId",
     "Id": 1008,
     "Code": "ModifiedOperationId",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The operation id has been changed from \u0027\u0027 to \u0027Operations_Get\u0027. This will impact generated code.",
     "OldJsonRef": "#/paths/~1api~1Operations/get/operationId",
     "NewJsonRef": "#/paths/~1api~1Operations/get/operationId",
+    "OldJsonPath": "#/paths/~1api~1Operations/get/operationId",
+    "NewJsonPath": "#/paths/~1api~1Operations/get/operationId",
     "Id": 1008,
     "Code": "ModifiedOperationId",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The operation id has been changed from \u0027Operations_Post\u0027 to \u0027\u0027. This will impact generated code.",
     "OldJsonRef": "#/paths/~1api~1Operations/post/operationId",
     "NewJsonRef": "#/paths/~1api~1Operations/post/operationId",
+    "OldJsonPath": "#/paths/~1api~1Operations/post/operationId",
+    "NewJsonPath": "#/paths/~1api~1Operations/post/operationId",
     "Id": 1008,
     "Code": "ModifiedOperationId",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/no_version_change/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/no_version_change/diff.json
@@ -4,6 +4,8 @@
     "Message": "The versions have not changed.",
     "OldJsonRef": "#/info/version",
     "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
     "Id": 1001,
     "Code": "NoVersionChange",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
+    "OldJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
+    "NewJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
     "Id": 2000,
     "Code": "NullablePropertyChanged",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
-    "OldJsonRef": "#/schemas/Pet/properties/tag/nullable",
-    "NewJsonRef": "#/schemas/Pet/properties/tag/nullable",
+    "OldJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
+    "NewJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
     "Id": 2000,
     "Code": "NullablePropertyChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
-    "NewJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
+    "OldJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
+    "NewJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
     "Id": 2000,
     "Code": "NullablePropertyChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
     "OldJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
     "NewJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
+    "OldJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
+    "NewJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
     "Id": 2000,
     "Code": "NullablePropertyChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_in_has_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_in_has_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "How the parameter is passed has changed -- it used to be \u0027query\u0027, now it is \u0027header\u0027.",
-    "OldJsonRef": "#/components/parameters/skipParam/in",
-    "NewJsonRef": "#/components/parameters/skipParam/in",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/in",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/in",
+    "OldJsonPath": "#/components/parameters/skipParam/in",
+    "NewJsonPath": "#/components/parameters/skipParam/in",
     "Id": 1015,
     "Code": "ParameterInHasChanged",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "How the parameter is passed has changed -- it used to be \u0027query\u0027, now it is \u0027header\u0027.",
-    "OldJsonRef": "#/components/parameters/limitParam/in",
-    "NewJsonRef": "#/components/parameters/limitParam/in",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/in",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/in",
+    "OldJsonPath": "#/components/parameters/limitParam/in",
+    "NewJsonPath": "#/components/parameters/limitParam/in",
     "Id": 1015,
     "Code": "ParameterInHasChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_in_has_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_in_has_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "How the parameter is passed has changed -- it used to be \u0027query\u0027, now it is \u0027header\u0027.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/in",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/in",
+    "OldJsonRef": "#/components/parameters/skipParam/in",
+    "NewJsonRef": "#/components/parameters/skipParam/in",
     "Id": 1015,
     "Code": "ParameterInHasChanged",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "How the parameter is passed has changed -- it used to be \u0027query\u0027, now it is \u0027header\u0027.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/in",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/in",
+    "OldJsonRef": "#/components/parameters/limitParam/in",
+    "NewJsonRef": "#/components/parameters/limitParam/in",
     "Id": 1015,
     "Code": "ParameterInHasChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_style_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_style_changed/diff.json
@@ -4,6 +4,8 @@
     "Message": "Parameter \u0027pageParam\u0027 has a different style value in the new version.",
     "OldJsonRef": "#/paths/~1pets/get/parameters/0/style",
     "NewJsonRef": "#/paths/~1pets/get/parameters/0/style",
+    "OldJsonPath": "#/paths/~1pets/get/parameters/0/style",
+    "NewJsonPath": "#/paths/~1pets/get/parameters/0/style",
     "Id": 10281,
     "Code": "ParameterStyleChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "Parameter \u0027PetId\u0027 has a different style value in the new version.",
     "OldJsonRef": "#/paths/~1pets~1{id}/parameters/0/style",
     "NewJsonRef": "#/paths/~1pets~1{id}/parameters/0/style",
+    "OldJsonPath": "#/paths/~1pets~1{id}/parameters/0/style",
+    "NewJsonPath": "#/paths/~1pets~1{id}/parameters/0/style",
     "Id": 10281,
     "Code": "ParameterStyleChanged",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "Parameter \u0027PetParameter\u0027 has a different style value in the new version.",
-    "OldJsonRef": "#/components/parameters/PetParameter/style",
-    "NewJsonRef": "#/components/parameters/PetParameter/style",
+    "OldJsonRef": "#/paths/~1pets~1{id}/post/parameters/0/style",
+    "NewJsonRef": "#/paths/~1pets~1{id}/post/parameters/0/style",
+    "OldJsonPath": "#/components/parameters/PetParameter/style",
+    "NewJsonPath": "#/components/parameters/PetParameter/style",
     "Id": 10281,
     "Code": "ParameterStyleChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_style_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/parameter_style_changed/diff.json
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "Parameter \u0027PetParameter\u0027 has a different style value in the new version.",
-    "OldJsonRef": "#/paths/~1pets~1{id}/post/parameters/0/style",
-    "NewJsonRef": "#/paths/~1pets~1{id}/post/parameters/0/style",
+    "OldJsonRef": "#/components/parameters/PetParameter/style",
+    "NewJsonRef": "#/components/parameters/PetParameter/style",
     "Id": 10281,
     "Code": "ParameterStyleChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/polymorphic_schema/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/polymorphic_schema/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a new optional property \u0027breed\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/schemas/Dog/properties/breed",
-    "NewJsonRef": "#/schemas/Dog/properties/breed",
+    "OldJsonRef": "#/components/schemas/Dog/properties/breed",
+    "NewJsonRef": "#/components/schemas/Dog/properties/breed",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/polymorphic_schema/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/polymorphic_schema/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version has a new optional property \u0027breed\u0027 that was not found in the old version.",
     "OldJsonRef": "#/components/schemas/Dog/properties/breed",
     "NewJsonRef": "#/components/schemas/Dog/properties/breed",
+    "OldJsonPath": "#/components/schemas/Dog/properties/breed",
+    "NewJsonPath": "#/components/schemas/Dog/properties/breed",
     "Id": 1045,
     "Code": "AddedOptionalProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/schemas/Pet/properties/name/readOnly",
-    "NewJsonRef": "#/schemas/Pet/properties/name/readOnly",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The read only property has changed from \u0027true\u0027 to \u0027false\u0027.",
     "OldJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
     "NewJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
+    "OldJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
+    "NewJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
     "OldJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
     "NewJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
-    "OldJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
-    "NewJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
+    "OldJsonRef": "#/components/schemas/CreateParamBody/properties/target",
+    "NewJsonRef": "#/components/schemas/CreateParamBody/properties/target",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
-    "NewJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
+    "OldJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "NewJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/schemas/CloudError/properties/error/properties/message/readOnly",
-    "NewJsonRef": "#/schemas/CloudError/properties/error/properties/message/readOnly",
+    "OldJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "NewJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
-    "OldJsonRef": "#/schemas/CreateParam/properties/error/properties/target",
-    "NewJsonRef": "#/schemas/CreateParam/properties/error/properties/target",
+    "OldJsonRef": "#/components/schemas/CreateParamBody/properties/target",
+    "NewJsonRef": "#/components/schemas/CreateParamBody/properties/target",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/CreateParamBody/properties/target",
-    "NewJsonRef": "#/components/schemas/CreateParamBody/properties/target",
+    "OldJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
+    "NewJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
+    "OldJsonPath": "#/components/schemas/CreateParamBody/properties/target",
+    "NewJsonPath": "#/components/schemas/CreateParamBody/properties/target",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
-    "NewJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "OldJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
+    "NewJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
+    "OldJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "NewJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
-    "NewJsonRef": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "OldJsonRef": "#/components/schemas/CloudError/properties/error/properties/message/readOnly",
+    "NewJsonRef": "#/components/schemas/CloudError/properties/error/properties/message/readOnly",
+    "OldJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
+    "NewJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/CreateParamBody/properties/target",
-    "NewJsonRef": "#/components/schemas/CreateParamBody/properties/target",
+    "OldJsonRef": "#/components/schemas/CreateParam/properties/error/properties/target",
+    "NewJsonRef": "#/components/schemas/CreateParam/properties/error/properties/target",
+    "OldJsonPath": "#/components/schemas/CreateParamBody/properties/target",
+    "NewJsonPath": "#/components/schemas/CreateParamBody/properties/target",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
@@ -10,6 +10,51 @@
   },
   {
     "Severity": "Warning",
+    "Message": "The new version has a different discriminator than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
+    "Id": 1030,
+    "Code": "DifferentDiscriminator",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version has a different type \u0027\u0027 than the previous one \u0027object\u0027.",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
+    "Id": 1032,
+    "Code": "DifferentAllOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version is missing a property found in the old version. Was \u0027name\u0027 renamed or removed?",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
+    "Id": 1033,
+    "Code": "RemovedProperty",
+    "Mode": "Removal"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version is missing a property found in the old version. Was \u0027petType\u0027 renamed or removed?",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "Id": 1033,
+    "Code": "RemovedProperty",
+    "Mode": "Removal"
+  },
+  {
+    "Severity": "Warning",
     "Message": "The \u0027$ref\u0027 property points to different models in the old and new versions.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
+    "OldJsonRef": "#/components/schemas/Pet/discriminator",
+    "NewJsonRef": "#/components/schemas/Cat/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027\u0027 than the previous one \u0027object\u0027.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
+    "OldJsonRef": "#/components/schemas/Pet/type",
+    "NewJsonRef": "#/components/schemas/Cat/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
+    "OldJsonRef": "#/components/schemas/Pet/allOf",
+    "NewJsonRef": "#/components/schemas/Cat/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"
@@ -38,8 +38,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027name\u0027 renamed or removed?",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name",
+    "NewJsonRef": "#/components/schemas/Cat/properties/name",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -47,8 +47,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027petType\u0027 renamed or removed?",
-    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
-    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
+    "NewJsonRef": "#/components/schemas/Cat/properties/petType",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection/diff.json
@@ -4,6 +4,8 @@
     "Message": "The \u0027$ref\u0027 property points to different models in the old and new versions.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items",
+    "OldJsonPath": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items",
+    "NewJsonPath": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items",
     "Id": 1017,
     "Code": "ReferenceRedirection",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/discriminator",
-    "NewJsonRef": "#/components/schemas/Cat/discriminator",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/discriminator",
+    "OldJsonPath": "#/components/schemas/Pet/discriminator",
+    "NewJsonPath": "#/components/schemas/Cat/discriminator",
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027\u0027 than the previous one \u0027object\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/type",
-    "NewJsonRef": "#/components/schemas/Cat/type",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/type",
+    "OldJsonPath": "#/components/schemas/Pet/type",
+    "NewJsonPath": "#/components/schemas/Cat/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different \u0027allOf\u0027 property than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/allOf",
-    "NewJsonRef": "#/components/schemas/Cat/allOf",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/allOf",
+    "OldJsonPath": "#/components/schemas/Pet/allOf",
+    "NewJsonPath": "#/components/schemas/Cat/allOf",
     "Id": 1032,
     "Code": "DifferentAllOf",
     "Mode": "Update"
@@ -38,8 +46,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027name\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name",
-    "NewJsonRef": "#/components/schemas/Cat/properties/name",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/name",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name",
+    "NewJsonPath": "#/components/schemas/Cat/properties/name",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -47,8 +57,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027petType\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
-    "NewJsonRef": "#/components/schemas/Cat/properties/petType",
+    "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType",
+    "NewJsonPath": "#/components/schemas/Cat/properties/petType",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -58,6 +70,8 @@
     "Message": "The \u0027$ref\u0027 property points to different models in the old and new versions.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",
+    "OldJsonPath": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",
+    "NewJsonPath": "#/paths/~1api~1Parameters/get/responses/400/content/application~1json/schema/items",
     "Id": 1017,
     "Code": "ReferenceRedirection",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
-    "NewJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
+    "OldJsonRef": "#/components/schemas/Order/properties/id/type",
+    "NewJsonRef": "#/components/schemas/Cart/properties/id/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a definition that was found in the old version. Was \u0027Order\u0027 removed or renamed?",
-    "OldJsonRef": "#/schemas/Order",
-    "NewJsonRef": "#/schemas/Order",
+    "OldJsonRef": "#/components/schemas/Order",
+    "NewJsonRef": "#/components/schemas/Order",
     "Id": 1006,
     "Code": "RemovedDefinition",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
@@ -4,6 +4,8 @@
     "Message": "The \u0027$ref\u0027 property points to different models in the old and new versions.",
     "OldJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
+    "OldJsonPath": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
+    "NewJsonPath": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
     "Id": 1017,
     "Code": "ReferenceRedirection",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/components/schemas/Order/properties/id/type",
-    "NewJsonRef": "#/components/schemas/Cart/properties/id/type",
+    "OldJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
+    "NewJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
+    "OldJsonPath": "#/components/schemas/Order/properties/id/type",
+    "NewJsonPath": "#/components/schemas/Cart/properties/id/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version is missing a definition that was found in the old version. Was \u0027Order\u0027 removed or renamed?",
     "OldJsonRef": "#/components/schemas/Order",
     "NewJsonRef": "#/components/schemas/Order",
+    "OldJsonPath": "#/components/schemas/Order",
+    "NewJsonPath": "#/components/schemas/Order",
     "Id": 1006,
     "Code": "RemovedDefinition",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/diff.json
@@ -1,0 +1,29 @@
+[
+  {
+    "Severity": "Warning",
+    "Message": "The \u0027$ref\u0027 property points to different models in the old and new versions.",
+    "OldJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
+    "NewJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items",
+    "Id": 1017,
+    "Code": "ReferenceRedirection",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
+    "OldJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
+    "NewJsonRef": "#/paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version is missing a definition that was found in the old version. Was \u0027Order\u0027 removed or renamed?",
+    "OldJsonRef": "#/schemas/Order",
+    "NewJsonRef": "#/schemas/Order",
+    "Id": 1006,
+    "Code": "RemovedDefinition",
+    "Mode": "Removal"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/new.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: My API
+  version: 0.2.0
+paths:
+  /orders:
+    get:
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Commande"
+components:
+  schemas:
+    Commande:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/new.yaml
@@ -13,10 +13,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Commande"
+                  $ref: "#/components/schemas/Cart"
 components:
   schemas:
-    Commande:
+    Cart:
       type: object
       properties:
         id:

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/reference_redirection_type_changed/old.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: My API
+  version: 0.1.0
+paths:
+  /orders:
+    get:
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
+    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "Id": 1022,
     "Code": "RemovedAdditionalProperties",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/schemas/Pet/additionalProperties",
+    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "Id": 1022,
     "Code": "RemovedAdditionalProperties",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
+    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1022,
     "Code": "RemovedAdditionalProperties",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
     "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
     "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
+    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
+    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1022,
     "Code": "RemovedAdditionalProperties",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_client_parameter/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_client_parameter/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing a client parameter that was found in the old version. Was \u0027limitParam\u0027 removed or renamed?",
     "OldJsonRef": "#/components/parameters/limitParam",
     "NewJsonRef": "#/components/parameters/limitParam",
+    "OldJsonPath": "#/components/parameters/limitParam",
+    "NewJsonPath": "#/components/parameters/limitParam",
     "Id": 1007,
     "Code": "RemovedClientParameter",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_client_parameter/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_client_parameter/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a client parameter that was found in the old version. Was \u0027limitParam\u0027 removed or renamed?",
-    "OldJsonRef": "#/parameters/limitParam",
-    "NewJsonRef": "#/parameters/limitParam",
+    "OldJsonRef": "#/components/parameters/limitParam",
+    "NewJsonRef": "#/components/parameters/limitParam",
     "Id": 1007,
     "Code": "RemovedClientParameter",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +29,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -38,8 +38,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -47,8 +47,8 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
-    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
-    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonPath": "#/components/parameters/limitParam/schema/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/parameters/limitParam/schema/enum",
-    "NewJsonRef": "#/components/parameters/limitParam/schema/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
+    "OldJsonPath": "#/components/parameters/limitParam/schema/enum",
+    "NewJsonPath": "#/components/parameters/limitParam/schema/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -29,8 +35,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"
@@ -38,8 +46,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1019,
     "Code": "RemovedEnumValue",
     "Mode": "Removal"
@@ -47,8 +57,10 @@
   {
     "Severity": "Info",
     "Message": "The new version has a more constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
+    "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
     "Id": 1024,
     "Code": "ConstraintIsStronger",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_header/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_header/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version removes a required header \u0027x-d\u0027.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
+    "OldJsonPath": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
+    "NewJsonPath": "#/paths/~1api~1Parameters/get/responses/200/headers/x-d",
     "Id": 1014,
     "Code": "RemovingHeader",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version removes a required header \u0027x-c\u0027.",
     "OldJsonRef": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
     "NewJsonRef": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
+    "OldJsonPath": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
+    "NewJsonPath": "#/paths/~1api~1Responses/get/responses/200/headers/x-c",
     "Id": 1014,
     "Code": "RemovingHeader",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_operation/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_operation/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing an operation that was found in the old version. Was operationId \u0027Operations_Post\u0027 removed or restructured?",
     "OldJsonRef": "#/paths/~1api~1Operations/post",
     "NewJsonRef": "#/paths/~1api~1Operations/post",
+    "OldJsonPath": "#/paths/~1api~1Operations/post",
+    "NewJsonPath": "#/paths/~1api~1Operations/post",
     "Id": 1035,
     "Code": "RemovedOperation",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_path/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_path/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing a path that was found in the old version. Was path \u0027/api/Parameters/{a}\u0027 removed or restructured?",
     "OldJsonRef": "#/paths/~1api~1Parameters~1{a}",
     "NewJsonRef": null,
+    "OldJsonPath": "#/paths/~1api~1Parameters~1{a}",
+    "NewJsonPath": null,
     "Id": 1005,
     "Code": "RemovedPath",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version is missing a path that was found in the old version. Was path \u0027/api/Responses\u0027 removed or restructured?",
     "OldJsonRef": "#/paths/~1api~1Responses",
     "NewJsonRef": null,
+    "OldJsonPath": "#/paths/~1api~1Responses",
+    "NewJsonPath": null,
     "Id": 1005,
     "Code": "RemovedPath",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_property/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027petType\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonPath": "#/components/schemas/Pet/properties/petType",
+    "NewJsonPath": "#/components/schemas/Pet/properties/petType",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version is missing a property found in the old version. Was \u0027message\u0027 renamed or removed?",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
+    "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema/properties/message",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"
@@ -22,6 +26,8 @@
     "Message": "The new version is missing a property found in the old version. Was \u0027status\u0027 renamed or removed?",
     "OldJsonRef": "#/paths/~1pets/get/requestBody/content/application~1json/schema/properties/status",
     "NewJsonRef": "#/paths/~1pets/get/requestBody/content/application~1json/schema/properties/status",
+    "OldJsonPath": "#/paths/~1pets/get/requestBody/content/application~1json/schema/properties/status",
+    "NewJsonPath": "#/paths/~1pets/get/requestBody/content/application~1json/schema/properties/status",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_property/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a property found in the old version. Was \u0027petType\u0027 renamed or removed?",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/petType",
+    "OldJsonRef": "#/components/schemas/Pet/properties/petType",
+    "NewJsonRef": "#/components/schemas/Pet/properties/petType",
     "Id": 1033,
     "Code": "RemovedProperty",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_request_body/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_request_body/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is removing a requestBody that was found in the old version.",
     "OldJsonRef": "#/paths/~1pets/post/requestBody",
     "NewJsonRef": "#/paths/~1pets/post/requestBody",
+    "OldJsonPath": "#/paths/~1pets/post/requestBody",
+    "NewJsonPath": "#/paths/~1pets/post/requestBody",
     "Id": 1047,
     "Code": "RemovedRequestBody",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_required_parameter/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_required_parameter/diff.json
@@ -4,6 +4,8 @@
     "Message": "The required parameter \u0027limitParam\u0027 was removed in the new version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1",
     "NewJsonRef": null,
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/parameters/1",
+    "NewJsonPath": null,
     "Id": 1009,
     "Code": "RemovedRequiredParameter",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_response_code/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_response_code/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version removes the response code \u0027200\u0027",
     "OldJsonRef": "#/paths/~1api~1Operations/post/responses/200",
     "NewJsonRef": "#/paths/~1api~1Operations/post/responses/200",
+    "OldJsonPath": "#/paths/~1api~1Operations/post/responses/200",
+    "NewJsonPath": "#/paths/~1api~1Operations/post/responses/200",
     "Id": 1012,
     "Code": "RemovedResponseCode",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version removes the response code \u0027202\u0027",
     "OldJsonRef": "#/paths/~1api~1Responses/get/responses/202",
     "NewJsonRef": "#/paths/~1api~1Responses/get/responses/202",
+    "OldJsonPath": "#/paths/~1api~1Responses/get/responses/202",
+    "NewJsonPath": "#/paths/~1api~1Responses/get/responses/202",
     "Id": 1012,
     "Code": "RemovedResponseCode",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version is missing a definition that was found in the old version. Was \u0027Pet\u0027 removed or renamed?",
-    "OldJsonRef": "#/schemas/Pet",
-    "NewJsonRef": "#/schemas/Pet",
+    "OldJsonRef": "#/components/schemas/Pet",
+    "NewJsonRef": "#/components/schemas/Pet",
     "Id": 1006,
     "Code": "RemovedDefinition",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing a definition that was found in the old version. Was \u0027Pet\u0027 removed or renamed?",
     "OldJsonRef": "#/components/schemas/Pet",
     "NewJsonRef": "#/components/schemas/Pet",
+    "OldJsonPath": "#/components/schemas/Pet",
+    "NewJsonPath": "#/components/schemas/Pet",
     "Id": 1006,
     "Code": "RemovedDefinition",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema_in_response/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_schema_in_response/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing a definition that was found in the old version. Was \u0027\u0027 removed or renamed?",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema",
     "Id": 1006,
     "Code": "RemovedDefinition",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_no_longer_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_no_longer_supported/diff.json
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version does not support \u0027text/plain\u0027 as a request body format.",
-    "OldJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/text~1plain",
-    "NewJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/text~1plain",
+    "OldJsonRef": "#/components/requestBodies/PetBody/content/text~1plain",
+    "NewJsonRef": "#/components/requestBodies/PetBody/content/text~1plain",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version does not support \u0027application/xml\u0027 as a request body format.",
-    "OldJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/application~1xml",
-    "NewJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/application~1xml",
+    "OldJsonRef": "#/components/requestBodies/PetBody/content/application~1xml",
+    "NewJsonRef": "#/components/requestBodies/PetBody/content/application~1xml",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_no_longer_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_no_longer_supported/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version does not support \u0027text/plain\u0027 as a request body format.",
     "OldJsonRef": "#/paths/~1pets/post/requestBody/content/text~1plain",
     "NewJsonRef": "#/paths/~1pets/post/requestBody/content/text~1plain",
+    "OldJsonPath": "#/paths/~1pets/post/requestBody/content/text~1plain",
+    "NewJsonPath": "#/paths/~1pets/post/requestBody/content/text~1plain",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version does not support \u0027application/xml\u0027 as a request body format.",
     "OldJsonRef": "#/paths/~1pets/post/requestBody/content/application~1xml",
     "NewJsonRef": "#/paths/~1pets/post/requestBody/content/application~1xml",
+    "OldJsonPath": "#/paths/~1pets/post/requestBody/content/application~1xml",
+    "NewJsonPath": "#/paths/~1pets/post/requestBody/content/application~1xml",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"
@@ -20,8 +24,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version does not support \u0027text/plain\u0027 as a request body format.",
-    "OldJsonRef": "#/components/requestBodies/PetBody/content/text~1plain",
-    "NewJsonRef": "#/components/requestBodies/PetBody/content/text~1plain",
+    "OldJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/text~1plain",
+    "NewJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/text~1plain",
+    "OldJsonPath": "#/components/requestBodies/PetBody/content/text~1plain",
+    "NewJsonPath": "#/components/requestBodies/PetBody/content/text~1plain",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"
@@ -29,8 +35,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version does not support \u0027application/xml\u0027 as a request body format.",
-    "OldJsonRef": "#/components/requestBodies/PetBody/content/application~1xml",
-    "NewJsonRef": "#/components/requestBodies/PetBody/content/application~1xml",
+    "OldJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/application~1xml",
+    "NewJsonRef": "#/paths/~1pets~1{id}/post/requestBody/content/application~1xml",
+    "OldJsonPath": "#/components/requestBodies/PetBody/content/application~1xml",
+    "NewJsonPath": "#/components/requestBodies/PetBody/content/application~1xml",
     "Id": 1003,
     "Code": "RequestBodyFormatNoLongerSupported",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_now_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/request_body_format_now_supported/diff.json
@@ -4,6 +4,8 @@
     "Message": "The old version did not support \u0027application/xml\u0027 as a request body format.",
     "OldJsonRef": "#/paths/~1pets/post/requestBody/content/application~1xml",
     "NewJsonRef": "#/paths/~1pets/post/requestBody/content/application~1xml",
+    "OldJsonPath": "#/paths/~1pets/post/requestBody/content/application~1xml",
+    "NewJsonPath": "#/paths/~1pets/post/requestBody/content/application~1xml",
     "Id": 1018,
     "Code": "RequestBodyFormatNowSupported",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/required_status_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/required_status_changed/diff.json
@@ -11,8 +11,8 @@
   {
     "Severity": "Info",
     "Message": "The \u0027required\u0027 status changed from the old version(\u0027True\u0027) to the new version(\u0027False\u0027).",
-    "OldJsonRef": "#/paths/~1pets/get/parameters/1/required",
-    "NewJsonRef": "#/paths/~1pets/get/parameters/1/required",
+    "OldJsonRef": "#/components/parameters/limit/required",
+    "NewJsonRef": "#/components/parameters/limit/required",
     "Id": 1025,
     "Code": "RequiredStatusChange",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/required_status_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/required_status_changed/diff.json
@@ -4,6 +4,8 @@
     "Message": "The \u0027required\u0027 status changed from the old version(\u0027True\u0027) to the new version(\u0027False\u0027).",
     "OldJsonRef": "#/paths/~1pets/get/parameters/0/required",
     "NewJsonRef": "#/paths/~1pets/get/parameters/0/required",
+    "OldJsonPath": "#/paths/~1pets/get/parameters/0/required",
+    "NewJsonPath": "#/paths/~1pets/get/parameters/0/required",
     "Id": 1025,
     "Code": "RequiredStatusChange",
     "Mode": "Update"
@@ -11,8 +13,10 @@
   {
     "Severity": "Info",
     "Message": "The \u0027required\u0027 status changed from the old version(\u0027True\u0027) to the new version(\u0027False\u0027).",
-    "OldJsonRef": "#/components/parameters/limit/required",
-    "NewJsonRef": "#/components/parameters/limit/required",
+    "OldJsonRef": "#/paths/~1pets/get/parameters/1/required",
+    "NewJsonRef": "#/paths/~1pets/get/parameters/1/required",
+    "OldJsonPath": "#/components/parameters/limit/required",
+    "NewJsonPath": "#/components/parameters/limit/required",
     "Id": 1025,
     "Code": "RequiredStatusChange",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The \u0027required\u0027 status changed from the old version(\u0027False\u0027) to the new version(\u0027True\u0027).",
     "OldJsonRef": "#/paths/~1pets/get/requestBody/required",
     "NewJsonRef": "#/paths/~1pets/get/requestBody/required",
+    "OldJsonPath": "#/paths/~1pets/get/requestBody/required",
+    "NewJsonPath": "#/paths/~1pets/get/requestBody/required",
     "Id": 1025,
     "Code": "RequiredStatusChange",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/response_body_format_now_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/response_body_format_now_supported/diff.json
@@ -4,6 +4,8 @@
     "Message": "The old version did not support \u0027application/xml\u0027 as a response body format.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1xml",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1xml",
+    "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1xml",
+    "NewJsonPath": "#/paths/~1pets/get/responses/200/content/application~1xml",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"
@@ -13,6 +15,8 @@
     "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
     "OldJsonRef": "#/paths/~1pets~1{id}/get/responses/200/content/text~1plain",
     "NewJsonRef": "#/paths/~1pets~1{id}/get/responses/200/content/text~1plain",
+    "OldJsonPath": "#/paths/~1pets~1{id}/get/responses/200/content/text~1plain",
+    "NewJsonPath": "#/paths/~1pets~1{id}/get/responses/200/content/text~1plain",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"
@@ -22,6 +26,19 @@
     "Message": "The old version did not support \u0027application/xml\u0027 as a response body format.",
     "OldJsonRef": "#/paths/~1pets~1{id}/get/responses/200/content/application~1xml",
     "NewJsonRef": "#/paths/~1pets~1{id}/get/responses/200/content/application~1xml",
+    "OldJsonPath": "#/paths/~1pets~1{id}/get/responses/200/content/application~1xml",
+    "NewJsonPath": "#/paths/~1pets~1{id}/get/responses/200/content/application~1xml",
+    "Id": 1004,
+    "Code": "ResponseBodyFormatNowSupported",
+    "Mode": "Addition"
+  },
+  {
+    "Severity": "Info",
+    "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
+    "OldJsonRef": "#/paths/~1pets~1{id}/get/responses/404/content/text~1plain",
+    "NewJsonRef": "#/paths/~1pets~1{id}/get/responses/404/content/text~1plain",
+    "OldJsonPath": "#/components/responses/ErrorResponse/content/text~1plain",
+    "NewJsonPath": "#/components/responses/ErrorResponse/content/text~1plain",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"
@@ -31,15 +48,8 @@
     "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
     "OldJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
     "NewJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
-    "Id": 1004,
-    "Code": "ResponseBodyFormatNowSupported",
-    "Mode": "Addition"
-  },
-  {
-    "Severity": "Info",
-    "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
-    "OldJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
-    "NewJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
+    "OldJsonPath": "#/components/responses/ErrorResponse/content/text~1plain",
+    "NewJsonPath": "#/components/responses/ErrorResponse/content/text~1plain",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/response_body_format_now_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/response_body_format_now_supported/diff.json
@@ -29,8 +29,8 @@
   {
     "Severity": "Info",
     "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
-    "OldJsonRef": "#/paths/~1pets~1{id}/get/responses/404/content/text~1plain",
-    "NewJsonRef": "#/paths/~1pets~1{id}/get/responses/404/content/text~1plain",
+    "OldJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
+    "NewJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"
@@ -38,8 +38,8 @@
   {
     "Severity": "Info",
     "Message": "The old version did not support \u0027text/plain\u0027 as a response body format.",
-    "OldJsonRef": "#/responses/ErrorResponse/content/text~1plain",
-    "NewJsonRef": "#/responses/ErrorResponse/content/text~1plain",
+    "OldJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
+    "NewJsonRef": "#/components/responses/ErrorResponse/content/text~1plain",
     "Id": 1004,
     "Code": "ResponseBodyFormatNowSupported",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/server_no_longer_supported/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/server_no_longer_supported/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version does not support the server with url \u0027https://staging.gigantic-server.com/v1\u0027 anymore",
     "OldJsonRef": "#/servers/1",
     "NewJsonRef": null,
+    "OldJsonPath": "#/servers/1",
+    "NewJsonPath": null,
     "Id": 10021,
     "Code": "ServerNoLongerSupported",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The new version does not support the server with url \u0027https://api.gigantic-server.com/v1\u0027 anymore",
     "OldJsonRef": "#/servers/2",
     "NewJsonRef": null,
+    "OldJsonPath": "#/servers/2",
+    "NewJsonPath": null,
     "Id": 10021,
     "Code": "ServerNoLongerSupported",
     "Mode": "Removal"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
@@ -2,8 +2,10 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/type",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/type",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/type",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -13,6 +15,8 @@
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
     "OldJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
     "NewJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
+    "OldJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
+    "NewJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
     "OldJsonRef": "#/components/schemas/Pet/properties/name/type",
     "NewJsonRef": "#/components/schemas/Pet/properties/name/type",
+    "OldJsonPath": "#/components/schemas/Pet/properties/name/type",
+    "NewJsonPath": "#/components/schemas/Pet/properties/name/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -31,6 +37,8 @@
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
     "OldJsonRef": "#/components/schemas/UnreferencedSchema/type",
     "NewJsonRef": "#/components/schemas/UnreferencedSchema/type",
+    "OldJsonPath": "#/components/schemas/UnreferencedSchema/type",
+    "NewJsonPath": "#/components/schemas/UnreferencedSchema/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/type",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/schemas/Pet/properties/name/type",
-    "NewJsonRef": "#/schemas/Pet/properties/name/type",
+    "OldJsonRef": "#/components/schemas/Pet/properties/name/type",
+    "NewJsonRef": "#/components/schemas/Pet/properties/name/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/schemas/UnreferencedSchema/type",
-    "NewJsonRef": "#/schemas/UnreferencedSchema/type",
+    "OldJsonRef": "#/components/schemas/UnreferencedSchema/type",
+    "NewJsonRef": "#/components/schemas/UnreferencedSchema/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
@@ -2,8 +2,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/sleepTime/format",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/sleepTime/format",
+    "OldJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
+    "NewJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"
@@ -11,8 +11,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/numberOfEyes/format",
-    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/numberOfEyes/format",
+    "OldJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "NewJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/properties/sleepTime/format",
-    "NewJsonRef": "#/schemas/Pet/properties/sleepTime/format",
+    "OldJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
+    "NewJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"
@@ -29,8 +29,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/schemas/Pet/properties/numberOfEyes/format",
-    "NewJsonRef": "#/schemas/Pet/properties/numberOfEyes/format",
+    "OldJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "NewJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
@@ -2,8 +2,32 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different format than the previous one.",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/sleepTime/format",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/sleepTime/format",
+    "OldJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
+    "NewJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
+    "Id": 1023,
+    "Code": "TypeFormatChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version has a different format than the previous one.",
+    "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/numberOfEyes/format",
+    "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/numberOfEyes/format",
+    "OldJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "NewJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "Id": 1023,
+    "Code": "TypeFormatChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Warning",
+    "Message": "The new version has a different format than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
     "NewJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
+    "OldJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
+    "NewJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"
@@ -13,24 +37,8 @@
     "Message": "The new version has a different format than the previous one.",
     "OldJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
     "NewJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "Id": 1023,
-    "Code": "TypeFormatChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
-    "NewJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
-    "Id": 1023,
-    "Code": "TypeFormatChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "NewJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "OldJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
+    "NewJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/version_reversed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/version_reversed/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version has a lower value than the old: System.String[] -\u003E System.String[]",
     "OldJsonRef": "#/info/version",
     "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
     "Id": 1000,
     "Code": "VersionsReversed",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/x-ms-paths/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/x-ms-paths/diff.json
@@ -20,8 +20,8 @@
   {
     "Severity": "Warning",
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/schemas/Cat/properties/sleepTime/type",
-    "NewJsonRef": "#/schemas/Cat/properties/sleepTime/type",
+    "OldJsonRef": "#/components/schemas/Cat/properties/sleepTime/type",
+    "NewJsonRef": "#/components/schemas/Cat/properties/sleepTime/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/x-ms-paths/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/x-ms-paths/diff.json
@@ -4,6 +4,8 @@
     "Message": "The new version is missing a path that was found in the old version. Was path \u0027/myPath/query-drive?op=file\u0027 removed or restructured?",
     "OldJsonRef": "#/x-ms-paths/~1myPath~1query-drive?op=file",
     "NewJsonRef": "#/x-ms-paths/~1myPath~1query-drive?op=file",
+    "OldJsonPath": "#/x-ms-paths/~1myPath~1query-drive?op=file",
+    "NewJsonPath": "#/x-ms-paths/~1myPath~1query-drive?op=file",
     "Id": 1005,
     "Code": "RemovedPath",
     "Mode": "Removal"
@@ -13,6 +15,8 @@
     "Message": "The \u0027required\u0027 status changed from the old version(\u0027False\u0027) to the new version(\u0027True\u0027).",
     "OldJsonRef": "#/x-ms-paths/~1myPath~1query-drive?op=folder/get/parameters/0/required",
     "NewJsonRef": "#/x-ms-paths/~1myPath~1query-drive?op=folder/get/parameters/0/required",
+    "OldJsonPath": "#/x-ms-paths/~1myPath~1query-drive?op=folder/get/parameters/0/required",
+    "NewJsonPath": "#/x-ms-paths/~1myPath~1query-drive?op=folder/get/parameters/0/required",
     "Id": 1025,
     "Code": "RequiredStatusChange",
     "Mode": "Update"
@@ -22,6 +26,8 @@
     "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
     "OldJsonRef": "#/components/schemas/Cat/properties/sleepTime/type",
     "NewJsonRef": "#/components/schemas/Cat/properties/sleepTime/type",
+    "OldJsonPath": "#/components/schemas/Cat/properties/sleepTime/type",
+    "NewJsonPath": "#/components/schemas/Cat/properties/sleepTime/type",
     "Id": 1026,
     "Code": "TypeChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator/Comparators/OpenApiDocumentComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/OpenApiDocumentComparator.cs
@@ -300,6 +300,8 @@ namespace Criteo.OpenApi.Comparator.Comparators
             TrackSchemasReference(oldDocument);
             TrackSchemasReference(newDocument);
 
+            context.PushProperty("components");
+
             CompareSchemas(context, oldDocument.Components.Schemas, newDocument.Components.Schemas);
 
             CompareParameters(context, oldDocument.Components.Parameters, newDocument.Components.Parameters);

--- a/src/Criteo.OpenApi.Comparator/Comparators/SchemaComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/SchemaComparator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Criteo Technology. All rights reserved.
+// Copyright (c) Criteo Technology. All rights reserved.
 // Licensed under the Apache 2.0 License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
@@ -45,7 +45,6 @@ namespace Criteo.OpenApi.Comparator.Comparators
                 && !newSchema.Reference.ReferenceV3.Equals(oldSchema.Reference?.ReferenceV3))
             {
                 context.LogBreakingChange(ComparisonRules.ReferenceRedirection);
-                return;
             }
 
             var areSchemasReferenced = false;

--- a/src/Criteo.OpenApi.Comparator/ComparisonMessage.cs
+++ b/src/Criteo.OpenApi.Comparator/ComparisonMessage.cs
@@ -81,6 +81,15 @@ namespace Criteo.OpenApi.Comparator
             ? Path.CompletePath(NewDocument.Token).LastOrDefault(t => t.token != null).token
             : Path.CompletePath(NewDocument.Token).LastOrDefault().token;
 
+        /// <summary>
+        /// JSON Pointer of the old resolved JSON reference
+        /// </summary>
+        public string OldJsonPath => Path.JsonPointer(OldDocument, resolveReferences: true);
+
+        /// <summary>
+        /// JSON Pointer of the new resolved JSON reference
+        /// </summary>
+        public string NewJsonPath => Path.JsonPointer(NewDocument, resolveReferences: true);
 
         /// <summary>
         /// The id of the validation message

--- a/src/Criteo.OpenApi.Comparator/Logging/ObjectPath.cs
+++ b/src/Criteo.OpenApi.Comparator/Logging/ObjectPath.cs
@@ -146,15 +146,17 @@ namespace Criteo.OpenApi.Comparator.Logging
         /// https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04
         /// </summary>
         /// <param name="jsonDocument"></param>
+        /// <param name="resolveReferences"></param>
         /// <returns>The json path of the json document</returns>
-        internal string JsonPointer(IJsonDocument jsonDocument)
+        internal string JsonPointer(IJsonDocument jsonDocument, bool resolveReferences = false)
         {
             string path = null;
             foreach (var (_, reference, name) in CompletePath(jsonDocument.Token))
             {
                 if (name == null)
                     return null;
-                path = reference ?? path;
+                if (resolveReferences)
+                    path = reference ?? path;
                 var escapedName = name.Replace("~", "~0").Replace("/", "~1");
                 path = path != null ? $"{path}/{escapedName}" : escapedName;
             }


### PR DESCRIPTION
Continue comparison of referenced schemas after a ref change so that we can still lint all modifications after renaming a model instead of only returning a breaking change for this rename.