### PR TITLE
feat: show parsing errors in stderr

### DIFF
--- a/src/Criteo.OpenApi.Comparator.Cli/Program.cs
+++ b/src/Criteo.OpenApi.Comparator.Cli/Program.cs
@@ -36,12 +36,21 @@ namespace Criteo.OpenApi.Comparator.Cli
 
             if (!oldFileFound || !newFileFound)
             {
-                Console.WriteLine("Exiting.");
+                Console.Error.WriteLine("Exiting.");
                 return 1;
             }
 
             var differences = OpenApiComparator.Compare(
-                oldOpenApiSpecification, newOpenApiSpecification, options.StrictMode);
+                oldOpenApiSpecification, newOpenApiSpecification, out var parsingErrors, options.StrictMode);
+
+            if (parsingErrors.Any())
+            {
+                Console.Error.WriteLine("Errors occurred while parsing the OpenAPI specifications:");
+                foreach (var error in parsingErrors)
+                {
+                    Console.Error.WriteLine(error);
+                }
+            }
 
             DisplayOutput(differences, options.OutputFormat);
 
@@ -66,7 +75,7 @@ namespace Criteo.OpenApi.Comparator.Cli
             }
             catch (UriFormatException)
             {
-                Console.WriteLine($"Failed to interpret the provided URI: {path}.");
+                Console.Error.WriteLine($"Failed to interpret the provided URI: {path}.");
                 fileContent = null;
             }
             return false;
@@ -81,7 +90,7 @@ namespace Criteo.OpenApi.Comparator.Cli
             }
             catch (FileNotFoundException)
             {
-                Console.WriteLine($"File not found for: {path}.");
+                Console.Error.WriteLine($"File not found for: {path}.");
                 fileContent = null;
                 return false;
             }
@@ -97,7 +106,7 @@ namespace Criteo.OpenApi.Comparator.Cli
             }
             catch (HttpRequestException exception)
             {
-                Console.WriteLine($"Http request failed on {path}: {exception.Message}");
+                Console.Error.WriteLine($"Http request failed on {path}: {exception.Message}");
             }
             catch (AggregateException exception)
             {
@@ -108,7 +117,7 @@ namespace Criteo.OpenApi.Comparator.Cli
                     stringWriter.Write($"- {innerException.GetType()}: {exception.Message}");
                     return true;
                 });
-                Console.WriteLine(stringWriter.ToString());
+                Console.Error.WriteLine(stringWriter.ToString());
             }
             fileContent = null;
             return false;

--- a/src/Criteo.OpenApi.Comparator.UTest/OpenApiParserTests.cs
+++ b/src/Criteo.OpenApi.Comparator.UTest/OpenApiParserTests.cs
@@ -29,7 +29,7 @@ namespace Criteo.OpenApi.Comparator.UTest
         {
             const string fileName = "invalid_json_file.txt";
             var documentAsString = ReadOpenApiFile(fileName);
-            Assert.Throws<OpenApiUnsupportedSpecVersionException>(() => OpenApiParser.Parse(documentAsString));
+            Assert.Throws<OpenApiUnsupportedSpecVersionException>(() => OpenApiParser.Parse(documentAsString, out _));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Criteo.OpenApi.Comparator.UTest
         public void OpenApiParser_Should_Return_Valid_OpenApi_Document_Object(string fileName)
         {
             var documentAsString = ReadOpenApiFile(fileName);
-            var validOpenApiDocument = OpenApiParser.Parse(documentAsString);
+            var validOpenApiDocument = OpenApiParser.Parse(documentAsString, out _);
             Assert.IsInstanceOf<JsonDocument<OpenApiDocument>>(validOpenApiDocument);
         }
     }

--- a/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
+++ b/src/Criteo.OpenApi.Comparator.UTest/OpenApiSpecificationsCompareTests.cs
@@ -44,7 +44,7 @@ public class OpenApiSpecificationsCompareTests
         var diffFileName = Path.Combine(resourceDirectory, testcase, "diff.json");
 
         var differences = OpenApiComparator
-            .Compare(File.ReadAllText(oldFileName), File.ReadAllText(newFileName));
+            .Compare(File.ReadAllText(oldFileName), File.ReadAllText(newFileName), out _);
 
         var expectedDifferencesText = File.ReadAllText(diffFileName);
         var expectedDifferences = JsonSerializer

--- a/src/Criteo.OpenApi.Comparator/OpenApiComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/OpenApiComparator.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache 2.0 License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Criteo.OpenApi.Comparator.Comparators;
 using Criteo.OpenApi.Comparator.Parser;
+using Microsoft.OpenApi.Models;
 
 namespace Criteo.OpenApi.Comparator
 {
@@ -17,11 +19,20 @@ namespace Criteo.OpenApi.Comparator
         /// </summary>
         /// <param name="oldOpenApiSpec">The content of the old OpenAPI Specification</param>
         /// <param name="newOpenApiSpec">The content of the new OpenAPI Specification</param>
+        /// <param name="parsingErrors">Parsing errors</param>
         /// <param name="strict">If true, then breaking changes are errors instead of warnings.</param>
-        public static IEnumerable<ComparisonMessage> Compare(string oldOpenApiSpec, string newOpenApiSpec, bool strict = false)
+        public static IEnumerable<ComparisonMessage> Compare(
+            string oldOpenApiSpec,
+            string newOpenApiSpec,
+            out IEnumerable<ParsingError> parsingErrors,
+            bool strict = false)
         {
-            var oldOpenApiDocument = OpenApiParser.Parse(oldOpenApiSpec);
-            var newOpenApiDocument = OpenApiParser.Parse(newOpenApiSpec);
+            var oldOpenApiDocument = OpenApiParser.Parse(oldOpenApiSpec, out var oldSpecDiagnostic);
+            var newOpenApiDocument = OpenApiParser.Parse(newOpenApiSpec, out var newSpecDiagnostic);
+
+            parsingErrors = oldSpecDiagnostic.Errors
+                .Select(e => new ParsingError("old", e))
+                .Concat(newSpecDiagnostic.Errors.Select(e => new ParsingError("new", e)));
 
             var context = new ComparisonContext(oldOpenApiDocument, newOpenApiDocument) { Strict = strict };
 
@@ -30,5 +41,28 @@ namespace Criteo.OpenApi.Comparator
 
             return comparisonMessages;
         }
+    }
+
+    /// <summary>
+    /// Represents an error that occurred while parsing an OpenAPI document.
+    /// </summary>
+    public class ParsingError
+    {
+        private readonly string _documentName;
+        private readonly OpenApiError _error;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParsingError"/> class.
+        /// </summary>
+        /// <param name="documentName"></param>
+        /// <param name="error"></param>
+        public ParsingError(string documentName, OpenApiError error)
+        {
+            _documentName = documentName;
+            _error = error;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString() => $"[{_documentName}] {_error}";
     }
 }

--- a/src/Criteo.OpenApi.Comparator/Parser/OpenApiParser.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/OpenApiParser.cs
@@ -15,14 +15,15 @@ namespace Criteo.OpenApi.Comparator.Parser
     internal static class OpenApiParser
     {
         /// <param name="openApiDocumentAsString">Swagger as string</param>
-        internal static JsonDocument<OpenApiDocument> Parse(string openApiDocumentAsString)
+        /// <param name="diagnostic"></param>
+        internal static JsonDocument<OpenApiDocument> Parse(string openApiDocumentAsString, out OpenApiDiagnostic diagnostic)
         {
             var openApiReaderSettings = new OpenApiReaderSettings
             {
                 ReferenceResolution = ReferenceResolutionSetting.DoNotResolveReferences
             };
             var openApiReader = new OpenApiStringReader(openApiReaderSettings);
-            var openApiDocument = openApiReader.Read(openApiDocumentAsString, out _);
+            var openApiDocument = openApiReader.Read(openApiDocumentAsString, out diagnostic);
 
             var textWriter = new StringWriter();
             var openApiWriter = new OpenApiJsonWriter(textWriter);


### PR DESCRIPTION
Example:

```
Errors occurred while parsing the OpenAPI specifications:
[old] The field 'version' in 'info' object is REQUIRED. [#/info/version]
[new] The field 'title' in 'info' object is REQUIRED. [#/info/title]
```

Also write the other occuring CLI errors in stderr instead of stdout.