### PR TITLE
Improve reporting of altered enum values

### DIFF
--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027bird\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
@@ -34,7 +34,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027bird\u0027 from the old version.",
     "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constant_status_has_changed/diff.json
@@ -12,7 +12,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString, Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027lazy, adventurous\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/enum",
     "OldJsonPath": "#/components/parameters/limitParam/schema/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_changed/diff.json
@@ -23,7 +23,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027item3\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",
@@ -34,7 +34,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027item4\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_stronger/diff.json
@@ -78,7 +78,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027item2\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",
     "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/properties/constrainsItems/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/constraint_is_weaker/diff.json
@@ -67,7 +67,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027item2\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "NewJsonRef": "#/paths/~1pets/get/parameters/0/schema/properties/constrainsItems/enum",
     "OldJsonPath": "#/components/schemas/limitParam/properties/constrainsItems/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_body_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027mno\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
@@ -23,7 +23,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_both_ref_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027mno\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",
@@ -23,7 +23,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027mno\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/requestBody/content/application~1json/schema/properties/foo/enum",
     "OldJsonPath": "#/components/schemas/RequestResponseEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_path_remove/diff.json
@@ -12,7 +12,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027def\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_query_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027ghi\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/parameters/1/schema/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_request_ref_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027def\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/parameters/0/schema/enum",
     "OldJsonPath": "#/components/schemas/RequestOnlyEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_add/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) \u0027zzzzzz\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_ref_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027ghi\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "OldJsonPath": "#/components/schemas/ResponseOnlyEnum/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/enum_direction_response_remove/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027stu\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "NewJsonRef": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",
     "OldJsonPath": "#/paths/~1order~1{path}/post/responses/200/content/application~1json/schema/properties/bar/enum",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_enum_value/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027lazy\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/0/schema/enum",
     "OldJsonPath": "#/components/parameters/limitParam/schema/enum",
@@ -23,7 +23,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027bird\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/parameters/1/schema/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
@@ -45,7 +45,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version is removing enum value(s) \u0027Microsoft.OpenApi.Any.OpenApiString\u0027 from the old version.",
+    "Message": "The new version is removing enum value(s) \u0027bird\u0027 from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",

--- a/src/Criteo.OpenApi.Comparator/Comparators/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/Extensions/OpenApiSchemaExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Criteo Technology. All rights reserved.
 // Licensed under the Apache 2.0 License. See LICENSE in the project root for license information.
 
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
 namespace Criteo.OpenApi.Comparator.Comparators.Extensions
@@ -9,5 +10,12 @@ namespace Criteo.OpenApi.Comparator.Comparators.Extensions
     {
         internal static bool IsPropertyRequired(this OpenApiSchema schema, string propertyName) =>
             schema.Required != null && schema.Required.Contains(propertyName);
+
+        internal static string StringValue(this IOpenApiAny openApiAny) =>
+            openApiAny switch
+            {
+                OpenApiString openApiString => openApiString.Value,
+                _ => openApiAny.ToString(),
+            };
     }
 }

--- a/src/Criteo.OpenApi.Comparator/Comparators/SchemaComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/SchemaComparator.cs
@@ -336,13 +336,13 @@ namespace Criteo.OpenApi.Comparator.Comparators
                 if (constrains)
                 {
                     LogAction logger = context.Direction == DataDirection.Response ? context.LogWarning : context.LogBreakingChange;
-                    logger(ComparisonRules.RemovedEnumValue, string.Join(", ", removedEnums));
+                    logger(ComparisonRules.RemovedEnumValue, string.Join(", ", removedEnums.Select(e => e.StringValue())));
                 }
 
                 if (relaxes && !IsEnumModelAsString(enumExtension))
                 {
                     LogAction logger = context.Direction == DataDirection.Request ? context.LogWarning : context.LogBreakingChange;
-                    logger(ComparisonRules.AddedEnumValue, string.Join(", ", addedEnums));
+                    logger(ComparisonRules.AddedEnumValue, string.Join(", ", addedEnums.Select(e => e.StringValue())));
                 }
             }
 


### PR DESCRIPTION
**This PR changes the diff for enums, so that the affected enum value appears in the list of differences - currently it just outputs** `Microsoft.OpenApi.Any.OpenApiString`.

This implementation handles only string enums, other types fall back to the type name, as it is now. The [OpenAPI spec](https://datatracker.ietf.org/doc/html/draft-fge-json-schema-validation-00#section-5.5.1) allows for values of _any_ type, though in practice I'm not sure if any other type would be seen in the wild (perhaps numeric)? If so, it would be easy to extend `OpenApiSchemaExtensions.StringValue()` with other types.

Thanks for the great tool 🙂