### PR TITLE
Bump version 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Any contribution is more than welcomed. For now, no specific rule must be applie
 
 OpenApi Comparator is an Open Source software released under the [Apache 2.0 license](https://github.com/criteo/openapi-comparator/blob/main/LICENCE).
 
-## Developper guide
+## Developer guide
 
 Simply use the dotnet cli. For example, to run the tests:
 ```bash

--- a/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
+++ b/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
@@ -15,7 +15,7 @@
     <Authors>Criteo</Authors>
     <Company>Criteo</Company>
     <Copyright>Copyright (c) Criteo Technology. All rights reserved.</Copyright>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <PackageProjectUrl>https://github.com/criteo/openapi-comparator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/criteo/openapi-comparator</RepositoryUrl>
     <PackageTags>Criteo, OpenApi, OpenApi-Comparator, OpenApi-Diff, Swagger</PackageTags>

--- a/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
+++ b/src/Criteo.OpenApi.Comparator.Cli/Criteo.OpenApi.Comparator.Cli.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6;net8;</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <OutputType>Exe</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Disable generation of fake program file done by Microsoft.NET.Test.Sdk in order to replace it with a static (*Demo.)Main method: -->
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/version_reversed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/version_reversed/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Error",
-    "Message": "The new version has a lower value than the old: System.String[] -\u003E System.String[]",
+    "Message": "The new version has a lower value than the old: 2.0 -> 1.0",
     "OldJsonRef": "#/info/version",
     "NewJsonRef": "#/info/version",
     "OldJsonPath": "#/info/version",

--- a/src/Criteo.OpenApi.Comparator/Comparators/OpenApiDocumentComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/OpenApiDocumentComparator.cs
@@ -113,7 +113,7 @@ namespace Criteo.OpenApi.Comparator.Comparators
 
                     if (oldMajor > newMajor)
                     {
-                        context.LogError(ComparisonRules.VersionsReversed, oldVersionAsList, newVersionAsList);
+                        context.LogError(ComparisonRules.VersionsReversed, oldVersion, newVersion);
                     }
                 }
 
@@ -128,7 +128,7 @@ namespace Criteo.OpenApi.Comparator.Comparators
 
                         if (oldMinor > newMinor)
                         {
-                            context.LogError(ComparisonRules.VersionsReversed, oldVersionAsList, newVersionAsList);
+                            context.LogError(ComparisonRules.VersionsReversed, oldVersion, newVersion);
                         }
                     }
                 }

--- a/src/Criteo.OpenApi.Comparator/Criteo.OpenApi.Comparator.csproj
+++ b/src/Criteo.OpenApi.Comparator/Criteo.OpenApi.Comparator.csproj
@@ -14,7 +14,7 @@
     <Authors>Criteo</Authors>
     <Company>Criteo</Company>
     <Copyright>Copyright (c) Criteo Technology. All rights reserved.</Copyright>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <PackageProjectUrl>https://github.com/criteo/openapi-comparator</PackageProjectUrl>
     <RepositoryUrl>https://github.com/criteo/openapi-comparator</RepositoryUrl>
     <PackageTags>Criteo, OpenApi, OpenApi-Comparator, OpenApi-Diff, Swagger</PackageTags>

--- a/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
@@ -116,7 +116,7 @@ namespace Criteo.OpenApi.Comparator.Parser
             {
                 var operation = (JProperty) jToken;
 
-                if (operation.Name.StartsWith("x-", StringComparison.InvariantCultureIgnoreCase)) continue;
+                if (operation.Name?.StartsWith("x-", StringComparison.InvariantCultureIgnoreCase)) continue;
 
                 result[operation.Name] = JsonConvert.DeserializeObject<OpenApiOperation>(
                     operation.Value.ToString(),

--- a/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
@@ -116,7 +116,7 @@ namespace Criteo.OpenApi.Comparator.Parser
             {
                 var operation = (JProperty) jToken;
 
-                if (operation.Name?.StartsWith("x-", StringComparison.InvariantCultureIgnoreCase)) continue;
+                if (operation.Name == null || operation.Name.StartsWith("x-", StringComparison.InvariantCultureIgnoreCase)) continue;
 
                 result[operation.Name] = JsonConvert.DeserializeObject<OpenApiOperation>(
                     operation.Value.ToString(),

--- a/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
+++ b/src/Criteo.OpenApi.Comparator/Parser/PathLevelParameterConverter.cs
@@ -116,7 +116,7 @@ namespace Criteo.OpenApi.Comparator.Parser
             {
                 var operation = (JProperty) jToken;
 
-                if (operation.Name == null || operation.Name.StartsWith("x-")) continue;
+                if (operation.Name.StartsWith("x-", StringComparison.InvariantCultureIgnoreCase)) continue;
 
                 result[operation.Name] = JsonConvert.DeserializeObject<OpenApiOperation>(
                     operation.Value.ToString(),


### PR DESCRIPTION
Change version to 0.8.2 in two .csproj
Minor fixes to address:
- https://github.com/criteo/openapi-comparator/issues/61
- https://github.com/criteo/openapi-comparator/issues/31