### PR TITLE
fix: correctly reset context direction

### DIFF
--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_additional_properties/diff.json
@@ -1,20 +1,9 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
+    "Message": "The new version adds an 'additionalProperties' element.",
     "OldJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
     "NewJsonRef": "#/paths/~1api~1Parameters/get/responses/200/content/application~1json/schema/additionalProperties",
-    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
-    "Id": 1021,
-    "Code": "AddedAdditionalProperties",
-    "Mode": "Addition"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version adds an \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
     "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1021,

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_enum_value/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027bird\u0027 from the old version.",
+    "Message": "The new version is adding enum value(s) 'bird' from the old version.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
@@ -12,7 +12,7 @@
   },
   {
     "Severity": "Info",
-    "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
+    "Message": "The new version has a less constraining 'enum' value than the previous one.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/petType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
@@ -23,42 +23,9 @@
   },
   {
     "Severity": "Info",
-    "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
+    "Message": "The new version has a less constraining 'enum' value than the previous one.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/properties/accountType/enum",
-    "OldJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
-    "NewJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
-    "Id": 1037,
-    "Code": "ConstraintIsWeaker",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version is adding enum value(s) \u0027bird\u0027 from the old version.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
-    "Id": 1020,
-    "Code": "AddedEnumValue",
-    "Mode": "Addition"
-  },
-  {
-    "Severity": "Info",
-    "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/petType/enum",
-    "OldJsonPath": "#/components/schemas/Pet/properties/petType/enum",
-    "NewJsonPath": "#/components/schemas/Pet/properties/petType/enum",
-    "Id": 1037,
-    "Code": "ConstraintIsWeaker",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Info",
-    "Message": "The new version has a less constraining \u0027enum\u0027 value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
-    "NewJsonRef": "#/components/schemas/Pet/properties/accountType/enum",
     "OldJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
     "NewJsonPath": "#/components/schemas/Pet/properties/accountType/enum",
     "Id": 1037,

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/added_required_property/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version has new required property \u0027petType\u0027 that was not found in the old version.",
+    "Message": "The new version has new required property 'petType' that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
     "OldJsonPath": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items",
@@ -12,22 +12,11 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version has new required property \u0027message\u0027 that was not found in the old version.",
+    "Message": "The new version has new required property 'message' that was not found in the old version.",
     "OldJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
     "NewJsonRef": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
     "OldJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
     "NewJsonPath": "#/paths/~1pets/get/responses/404/content/application~1json/schema",
-    "Id": 1034,
-    "Code": "AddedRequiredProperty",
-    "Mode": "Addition"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has new required property \u0027petType\u0027 that was not found in the old version.",
-    "OldJsonRef": "#/components/schemas/Pet",
-    "NewJsonRef": "#/components/schemas/Pet",
-    "OldJsonPath": "#/components/schemas/Pet",
-    "NewJsonPath": "#/components/schemas/Pet",
     "Id": 1034,
     "Code": "AddedRequiredProperty",
     "Mode": "Addition"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/default_value_changed/diff.json
@@ -20,16 +20,5 @@
     "Id": 1027,
     "Code": "DefaultValueChanged",
     "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different default value than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/default",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/default",
-    "OldJsonPath": "#/components/schemas/Pet/properties/name/default",
-    "NewJsonPath": "#/components/schemas/Pet/properties/name/default",
-    "Id": 1027,
-    "Code": "DefaultValueChanged",
-    "Mode": "Update"
   }
 ]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/different_discriminator/diff.json
@@ -31,16 +31,5 @@
     "Id": 1030,
     "Code": "DifferentDiscriminator",
     "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different discriminator than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/discriminator",
-    "NewJsonRef": "#/components/schemas/Pet/discriminator",
-    "OldJsonPath": "#/components/schemas/Pet/discriminator",
-    "NewJsonPath": "#/components/schemas/Pet/discriminator",
-    "Id": 1030,
-    "Code": "DifferentDiscriminator",
-    "Mode": "Update"
   }
 ]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/diff.json
@@ -1,0 +1,35 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a new property 'testHiddenNotNullableProperty' in response that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema/properties/testHiddenNotNullableProperty",
+    "NewJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema/properties/testHiddenNotNullableProperty",
+    "OldJsonPath": "#/components/schemas/ContentModel/properties/testHiddenNotNullableProperty",
+    "NewJsonPath": "#/components/schemas/ContentModel/properties/testHiddenNotNullableProperty",
+    "Id": 1041,
+    "Code": "AddedPropertyInResponse",
+    "Mode": "Addition"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has new required property 'testHiddenNotNullableProperty' that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "NewJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "Id": 1034,
+    "Code": "AddedRequiredProperty",
+    "Mode": "Addition"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/new.yaml
@@ -1,0 +1,70 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/v1/public/productContent:
+    get:
+      operationId: PublicDevice_GetProductContent
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentModel'
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    ContentModel:
+      type: object
+      additionalProperties: false
+      required:
+        - testHiddenNotNullableProperty
+      properties:
+        name:
+          type: string
+          nullable: true
+        testHiddenNotNullableProperty:
+          type: string
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case1/old.yaml
@@ -1,0 +1,66 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/v1/public/productContent:
+    get:
+      operationId: PublicDevice_GetProductContent
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentModel'
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    ContentModel:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          nullable: true
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/diff.json
@@ -1,0 +1,35 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a new property 'testHiddenNotNullableProperty' in response that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema/properties/testHiddenNotNullableProperty",
+    "NewJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema/properties/testHiddenNotNullableProperty",
+    "OldJsonPath": "#/components/schemas/ContentModel/properties/testHiddenNotNullableProperty",
+    "NewJsonPath": "#/components/schemas/ContentModel/properties/testHiddenNotNullableProperty",
+    "Id": 1041,
+    "Code": "AddedPropertyInResponse",
+    "Mode": "Addition"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has new required property 'testHiddenNotNullableProperty' that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "NewJsonRef": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1v1~1public~1productContent/get/responses/200/content/application~1json/schema",
+    "Id": 1034,
+    "Code": "AddedRequiredProperty",
+    "Mode": "Addition"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/new.yaml
@@ -1,0 +1,70 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+  /api/v1/public/productContent:
+    get:
+      operationId: PublicDevice_GetProductContent
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentModel'
+components:
+  schemas:
+    ContentModel:
+      type: object
+      additionalProperties: false
+      required:
+        - testHiddenNotNullableProperty
+      properties:
+        name:
+          type: string
+          nullable: true
+        testHiddenNotNullableProperty:
+          type: string
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/issue_59_case2/old.yaml
@@ -1,0 +1,66 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: true
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+  /api/v1/public/productContent:
+    get:
+      operationId: PublicDevice_GetProductContent
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentModel'
+components:
+  schemas:
+    ContentModel:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          nullable: true
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/nullable_property_changed/diff.json
@@ -1,20 +1,9 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
+    "Message": "The nullable property has changed from 'true' to 'false'.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/tag/nullable",
-    "OldJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
-    "NewJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
-    "Id": 2000,
-    "Code": "NullablePropertyChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The nullable property has changed from \u0027true\u0027 to \u0027false\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
-    "NewJsonRef": "#/components/schemas/Pet/properties/tag/nullable",
     "OldJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
     "NewJsonPath": "#/components/schemas/Pet/properties/tag/nullable",
     "Id": 2000,

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/readonly_property_changed/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
+    "Message": "The read only property has changed from 'false' to 'true'.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/readOnly",
     "OldJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
@@ -12,22 +12,11 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The read only property has changed from \u0027true\u0027 to \u0027false\u0027.",
+    "Message": "The read only property has changed from 'true' to 'false'.",
     "OldJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
     "NewJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
     "OldJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
     "NewJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/readOnly",
-    "Id": 1029,
-    "Code": "ReadonlyPropertyChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/readOnly",
-    "OldJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
-    "NewJsonPath": "#/components/schemas/Pet/properties/name/readOnly",
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/recursive_model/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
+    "Message": "The new version is missing a property found in the old version. Was 'target' renamed or removed?",
     "OldJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
     "NewJsonRef": "#/paths/~1api~1Operations/post/parameters/0/schema/properties/error/properties/target",
     "OldJsonPath": "#/components/schemas/CreateParamBody/properties/target",
@@ -12,7 +12,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
+    "Message": "The read only property has changed from 'false' to 'true'.",
     "OldJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
     "NewJsonRef": "#/paths/~1api~1Operations/post/responses/default/content/application~1json/schema/properties/error/properties/message/readOnly",
     "OldJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
@@ -20,27 +20,5 @@
     "Id": 1029,
     "Code": "ReadonlyPropertyChanged",
     "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The read only property has changed from \u0027false\u0027 to \u0027true\u0027.",
-    "OldJsonRef": "#/components/schemas/CloudError/properties/error/properties/message/readOnly",
-    "NewJsonRef": "#/components/schemas/CloudError/properties/error/properties/message/readOnly",
-    "OldJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
-    "NewJsonPath": "#/components/schemas/CloudErrorBody/properties/message/readOnly",
-    "Id": 1029,
-    "Code": "ReadonlyPropertyChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version is missing a property found in the old version. Was \u0027target\u0027 renamed or removed?",
-    "OldJsonRef": "#/components/schemas/CreateParam/properties/error/properties/target",
-    "NewJsonRef": "#/components/schemas/CreateParam/properties/error/properties/target",
-    "OldJsonPath": "#/components/schemas/CreateParamBody/properties/target",
-    "NewJsonPath": "#/components/schemas/CreateParamBody/properties/target",
-    "Id": 1033,
-    "Code": "RemovedProperty",
-    "Mode": "Removal"
   }
 ]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/removed_additional_properties/diff.json
@@ -1,20 +1,9 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
+    "Message": "The new version removes the 'additionalProperties' element.",
     "OldJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
     "NewJsonRef": "#/paths/~1api~1Parameters/put/responses/200/content/application~1json/schema/additionalProperties",
-    "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
-    "Id": 1022,
-    "Code": "RemovedAdditionalProperties",
-    "Mode": "Removal"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version removes the \u0027additionalProperties\u0027 element.",
-    "OldJsonRef": "#/components/schemas/Pet/additionalProperties",
-    "NewJsonRef": "#/components/schemas/Pet/additionalProperties",
     "OldJsonPath": "#/components/schemas/Pet/additionalProperties",
     "NewJsonPath": "#/components/schemas/Pet/additionalProperties",
     "Id": 1022,

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_changed/diff.json
@@ -1,7 +1,7 @@
 [
   {
     "Severity": "Warning",
-    "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
+    "Message": "The new version has a different type 'string' than the previous one 'integer'.",
     "OldJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
     "NewJsonRef": "#/paths/~1pets/get/responses/200/content/application~1json/schema/items/properties/name/type",
     "OldJsonPath": "#/components/schemas/Pet/properties/name/type",
@@ -12,7 +12,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
+    "Message": "The new version has a different type 'string' than the previous one 'integer'.",
     "OldJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
     "NewJsonRef": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
     "OldJsonPath": "#/paths/~1pets/get/responses/default/content/application~1json/schema/type",
@@ -23,18 +23,7 @@
   },
   {
     "Severity": "Warning",
-    "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/name/type",
-    "NewJsonRef": "#/components/schemas/Pet/properties/name/type",
-    "OldJsonPath": "#/components/schemas/Pet/properties/name/type",
-    "NewJsonPath": "#/components/schemas/Pet/properties/name/type",
-    "Id": 1026,
-    "Code": "TypeChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different type \u0027string\u0027 than the previous one \u0027integer\u0027.",
+    "Message": "The new version has a different type 'string' than the previous one 'integer'.",
     "OldJsonRef": "#/components/schemas/UnreferencedSchema/type",
     "NewJsonRef": "#/components/schemas/UnreferencedSchema/type",
     "OldJsonPath": "#/components/schemas/UnreferencedSchema/type",

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/type_format_changed/diff.json
@@ -20,27 +20,5 @@
     "Id": 1023,
     "Code": "TypeFormatChanged",
     "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
-    "NewJsonRef": "#/components/schemas/Pet/properties/sleepTime/format",
-    "OldJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
-    "NewJsonPath": "#/components/schemas/Pet/properties/sleepTime/format",
-    "Id": 1023,
-    "Code": "TypeFormatChanged",
-    "Mode": "Update"
-  },
-  {
-    "Severity": "Warning",
-    "Message": "The new version has a different format than the previous one.",
-    "OldJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "NewJsonRef": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "OldJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "NewJsonPath": "#/components/schemas/Pet/properties/numberOfEyes/format",
-    "Id": 1023,
-    "Code": "TypeFormatChanged",
-    "Mode": "Update"
   }
 ]

--- a/src/Criteo.OpenApi.Comparator/Comparators/ParameterComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ParameterComparator.cs
@@ -28,46 +28,45 @@ namespace Criteo.OpenApi.Comparator.Comparators
         {
             ComponentComparator<OpenApiParameter>.Compare(context, oldParameter, newParameter);
 
-            context.Direction = DataDirection.Request;
-
-            var areParametersReferenced = false;
-
-            if (!string.IsNullOrWhiteSpace(oldParameter.Reference?.ReferenceV3))
+            using (context.WithDirection(DataDirection.Request))
             {
-                oldParameter = FindReferencedParameter(oldParameter.Reference, context.OldOpenApiDocument.Components.Parameters);
-                areParametersReferenced = true;
-                if (oldParameter == null)
-                    return;
+                var areParametersReferenced = false;
+
+                if (!string.IsNullOrWhiteSpace(oldParameter.Reference?.ReferenceV3))
+                {
+                    oldParameter = FindReferencedParameter(oldParameter.Reference, context.OldOpenApiDocument.Components.Parameters);
+                    areParametersReferenced = true;
+                    if (oldParameter == null)
+                        return;
+                }
+                if (!string.IsNullOrWhiteSpace(newParameter.Reference?.ReferenceV3))
+                {
+                    newParameter = FindReferencedParameter(newParameter.Reference, context.NewOpenApiDocument.Components.Parameters);
+                    areParametersReferenced = true;
+                    if (newParameter == null)
+                        return;
+                }
+
+                if (areParametersReferenced)
+                {
+                    if (_visitedParameters.Contains(oldParameter))
+                        return;
+
+                    _visitedParameters.AddFirst(oldParameter);
+                }
+
+                CompareIn(context, oldParameter.In, newParameter.In);
+
+                CompareConstantStatus(context, oldParameter, newParameter);
+
+                CompareRequiredStatus(context, oldParameter, newParameter);
+
+                CompareStyle(context, oldParameter, newParameter);
+
+                CompareSchema(context, oldParameter.Schema, newParameter.Schema);
+
+                _contentComparator.Compare(context, oldParameter.Content, newParameter.Content);
             }
-            if (!string.IsNullOrWhiteSpace(newParameter.Reference?.ReferenceV3))
-            {
-                newParameter = FindReferencedParameter(newParameter.Reference, context.NewOpenApiDocument.Components.Parameters);
-                areParametersReferenced = true;
-                if (newParameter == null)
-                    return;
-            }
-
-            if (areParametersReferenced)
-            {
-                if (_visitedParameters.Contains(oldParameter))
-                    return;
-
-                _visitedParameters.AddFirst(oldParameter);
-            }
-
-            CompareIn(context, oldParameter.In, newParameter.In);
-
-            CompareConstantStatus(context, oldParameter, newParameter);
-
-            CompareRequiredStatus(context, oldParameter, newParameter);
-
-            CompareStyle(context, oldParameter, newParameter);
-
-            CompareSchema(context, oldParameter.Schema, newParameter.Schema);
-
-            _contentComparator.Compare(context, oldParameter.Content, newParameter.Content);
-
-            context.Direction = DataDirection.None;
         }
 
         private static void CompareIn(ComparisonContext context,

--- a/src/Criteo.OpenApi.Comparator/Comparators/RequestBodyComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/RequestBodyComparator.cs
@@ -18,42 +18,42 @@ namespace Criteo.OpenApi.Comparator.Comparators
         internal void Compare(ComparisonContext context,
             OpenApiRequestBody oldRequestBody, OpenApiRequestBody newRequestBody)
         {
-            context.Direction = DataDirection.Request;
-
-            if (oldRequestBody == null && newRequestBody == null)
-                return;
-
-            if (oldRequestBody == null)
+            using (context.WithDirection(DataDirection.Request))
             {
-                context.LogBreakingChange(ComparisonRules.AddedRequestBody);
-                return;
-            }
 
-            if (newRequestBody == null)
-            {
-                context.LogBreakingChange(ComparisonRules.RemovedRequestBody);
-                return;
-            }
+                if (oldRequestBody == null && newRequestBody == null)
+                    return;
 
-            if (!string.IsNullOrWhiteSpace(oldRequestBody.Reference?.ReferenceV3))
-            {
-                oldRequestBody = oldRequestBody.Reference.Resolve(context.OldOpenApiDocument.Components.RequestBodies);
                 if (oldRequestBody == null)
+                {
+                    context.LogBreakingChange(ComparisonRules.AddedRequestBody);
                     return;
-            }
+                }
 
-            if (!string.IsNullOrWhiteSpace(newRequestBody.Reference?.ReferenceV3))
-            {
-                newRequestBody = newRequestBody.Reference.Resolve(context.NewOpenApiDocument.Components.RequestBodies);
                 if (newRequestBody == null)
+                {
+                    context.LogBreakingChange(ComparisonRules.RemovedRequestBody);
                     return;
+                }
+
+                if (!string.IsNullOrWhiteSpace(oldRequestBody.Reference?.ReferenceV3))
+                {
+                    oldRequestBody = oldRequestBody.Reference.Resolve(context.OldOpenApiDocument.Components.RequestBodies);
+                    if (oldRequestBody == null)
+                        return;
+                }
+
+                if (!string.IsNullOrWhiteSpace(newRequestBody.Reference?.ReferenceV3))
+                {
+                    newRequestBody = newRequestBody.Reference.Resolve(context.NewOpenApiDocument.Components.RequestBodies);
+                    if (newRequestBody == null)
+                        return;
+                }
+
+                CompareRequired(context, oldRequestBody.Required, newRequestBody.Required);
+
+                _contentComparator.Compare(context, oldRequestBody.Content, newRequestBody.Content);
             }
-
-            CompareRequired(context, oldRequestBody.Required, newRequestBody.Required);
-
-            _contentComparator.Compare(context, oldRequestBody.Content, newRequestBody.Content);
-
-            context.Direction = DataDirection.None;
         }
 
         private static void CompareRequired(ComparisonContext context,

--- a/src/Criteo.OpenApi.Comparator/Comparators/ResponseComparator.cs
+++ b/src/Criteo.OpenApi.Comparator/Comparators/ResponseComparator.cs
@@ -21,27 +21,26 @@ namespace Criteo.OpenApi.Comparator.Comparators
         {
             ComponentComparator<OpenApiResponse>.Compare(context, oldResponse, newResponse);
 
-            context.Direction = DataDirection.Response;
-
-            if (!string.IsNullOrWhiteSpace(oldResponse.Reference?.ReferenceV3))
+            using (context.WithDirection(DataDirection.Response))
             {
-                oldResponse = oldResponse.Reference.Resolve(context.OldOpenApiDocument.Components.Responses);
-                if (oldResponse == null)
-                    return;
+                if (!string.IsNullOrWhiteSpace(oldResponse.Reference?.ReferenceV3))
+                {
+                    oldResponse = oldResponse.Reference.Resolve(context.OldOpenApiDocument.Components.Responses);
+                    if (oldResponse == null)
+                        return;
+                }
+
+                if (!string.IsNullOrWhiteSpace(newResponse.Reference?.ReferenceV3))
+                {
+                    newResponse = newResponse.Reference.Resolve(context.NewOpenApiDocument.Components.Responses);
+                    if (newResponse == null)
+                        return;
+                }
+
+                CompareHeaders(context, oldResponse.Headers, newResponse.Headers);
+
+                _contentComparator.Compare(context, oldResponse.Content, newResponse.Content);
             }
-
-            if (!string.IsNullOrWhiteSpace(newResponse.Reference?.ReferenceV3))
-            {
-                newResponse = newResponse.Reference.Resolve(context.NewOpenApiDocument.Components.Responses);
-                if (newResponse == null)
-                    return;
-            }
-
-            CompareHeaders(context, oldResponse.Headers, newResponse.Headers);
-
-            _contentComparator.Compare(context, oldResponse.Content, newResponse.Content);
-
-            context.Direction = DataDirection.None;
         }
 
         private static void CompareHeaders(ComparisonContext context,

--- a/src/Criteo.OpenApi.Comparator/ComparisonContext.cs
+++ b/src/Criteo.OpenApi.Comparator/ComparisonContext.cs
@@ -43,7 +43,15 @@ namespace Criteo.OpenApi.Comparator
         internal bool Strict { get; set; }
 
         /// Request, Response, Both or None
-        internal DataDirection Direction { get; set; } = DataDirection.None;
+        private readonly DisposableDataDirection _direction = new();
+
+        internal DataDirection Direction => _direction.Direction;
+
+        internal IDisposable WithDirection(DataDirection direction)
+        {
+            _direction.Direction = direction;
+            return _direction;
+        }
 
         private ObjectPath Path => _path.Peek();
 
@@ -115,6 +123,13 @@ namespace Criteo.OpenApi.Comparator
         }
 
         private readonly IList<ComparisonMessage> _messages = new List<ComparisonMessage>();
+    }
+
+    internal class DisposableDataDirection : IDisposable
+    {
+        public DataDirection Direction { get; set; }
+
+        public void Dispose() => Direction = DataDirection.None;
     }
 
     /// <summary>

--- a/src/Criteo.OpenApi.Comparator/ComparisonContext.cs
+++ b/src/Criteo.OpenApi.Comparator/ComparisonContext.cs
@@ -45,7 +45,7 @@ namespace Criteo.OpenApi.Comparator
         /// Request, Response, Both or None
         private readonly DisposableDataDirection _direction = new();
 
-        internal DataDirection Direction => _direction.Direction;
+        internal DataDirection Direction { get => _direction.Direction; set => _direction.Direction = value; }
 
         internal IDisposable WithDirection(DataDirection direction)
         {


### PR DESCRIPTION
Fix #59.

The issue #59 was caused by the fact that the context direction was not reset to "None" when early exiting a Compare method.

This was causing SchemaComparator.Compare to sometimes enter the `context.Direction != DataDirection.None` branch when it should not.

Preferred merge strategy: squash