### PR TITLE
feat: add support for oneOf comparison

### DIFF
--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/diff.json
@@ -1,0 +1,79 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different type '' than the previous one 'object'.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/type",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/type",
+    "OldJsonPath": "#/components/schemas/TicketObject/type",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "OldJsonPath": "#/components/schemas/TicketObject/oneOf",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version is missing a property found in the old version. Was 'allow_attachments' renamed or removed?",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/properties/allow_attachments",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/properties/allow_attachments",
+    "OldJsonPath": "#/components/schemas/TicketObject/properties/allow_attachments",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket/properties/allow_attachments",
+    "Id": 1033,
+    "Code": "RemovedProperty",
+    "Mode": "Removal"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different type '' than the previous one 'object'.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "OldJsonPath": "#/components/schemas/TicketPostRequest/type",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "OldJsonPath": "#/components/schemas/TicketPostRequest/oneOf",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version is missing a property found in the old version. Was 'email' renamed or removed?",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/properties/email",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/properties/email",
+    "OldJsonPath": "#/components/schemas/TicketPostRequest/properties/email",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/properties/email",
+    "Id": 1033,
+    "Code": "RemovedProperty",
+    "Mode": "Removal"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/new.yaml
@@ -1,0 +1,47 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add/old.yaml
@@ -1,0 +1,45 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/diff.json
@@ -1,0 +1,35 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/new.yaml
@@ -1,0 +1,51 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+                - $ref: '#/components/schemas/TicketObject'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+            - $ref: '#/components/schemas/TicketPostRequest'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_add_ref/old.yaml
@@ -1,0 +1,49 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/diff.json
@@ -1,0 +1,24 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has new required property 'testNullableProperty' that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf/0",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf/0",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf/0",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf/0",
+    "Id": 1034,
+    "Code": "AddedRequiredProperty",
+    "Mode": "Addition"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/new.yaml
@@ -1,0 +1,52 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+        - testNullableProperty
+      properties:
+        email:
+          type: string
+          minLength: 1
+        testNullableProperty:
+          type: string

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change/old.yaml
@@ -1,0 +1,49 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/diff.json
@@ -1,0 +1,101 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The '$ref' property points to different models in the old and new versions.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket",
+    "Id": 1017,
+    "Code": "ReferenceRedirection",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different type 'object' than the previous one ''.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/type",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/type",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket/type",
+    "NewJsonPath": "#/components/schemas/TicketObject/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "NewJsonPath": "#/components/schemas/TicketObject/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a new property 'allow_attachments' in response that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/properties/allow_attachments",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/properties/allow_attachments",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket/properties/allow_attachments",
+    "NewJsonPath": "#/components/schemas/TicketObject/properties/allow_attachments",
+    "Id": 1041,
+    "Code": "AddedPropertyInResponse",
+    "Mode": "Addition"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The '$ref' property points to different models in the old and new versions.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "Id": 1017,
+    "Code": "ReferenceRedirection",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different type 'object' than the previous one ''.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/type",
+    "NewJsonPath": "#/components/schemas/TicketPostRequest/type",
+    "Id": 1026,
+    "Code": "TypeChanged",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonPath": "#/components/schemas/TicketPostRequest/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has new required property 'email' that was not found in the old version.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema",
+    "Id": 1034,
+    "Code": "AddedRequiredProperty",
+    "Mode": "Addition"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/new.yaml
@@ -1,0 +1,45 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove/old.yaml
@@ -1,0 +1,47 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/diff.json
@@ -1,0 +1,35 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/responses/200/content/application~1json/schema/properties/ticket/oneOf",
+    "OldJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "NewJsonPath": "#/components/schemas/TicketResponse/properties/ticket/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  },
+  {
+    "Severity": "Error",
+    "Message": "The new version has a different 'oneOf' property than the previous one.",
+    "OldJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonRef": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "OldJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "NewJsonPath": "#/paths/~1api~1public~1form/post/requestBody/content/application~1json/schema/oneOf",
+    "Id": 10321,
+    "Code": "DifferentOneOf",
+    "Mode": "Update"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/new.yaml
@@ -1,0 +1,49 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_remove_ref/old.yaml
@@ -1,0 +1,51 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+                - $ref: '#/components/schemas/TicketObject'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+            - $ref: '#/components/schemas/TicketPostRequest'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/diff.json
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/diff.json
@@ -1,0 +1,13 @@
+[
+  {
+    "Severity": "Info",
+    "Message": "The versions have not changed.",
+    "OldJsonRef": "#/info/version",
+    "NewJsonRef": "#/info/version",
+    "OldJsonPath": "#/info/version",
+    "NewJsonPath": "#/info/version",
+    "Id": 1001,
+    "Code": "NoVersionChange",
+    "Mode": "Update"
+  }
+]

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/new.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/new.yaml
@@ -1,0 +1,51 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketObject'
+                - $ref: '#/components/schemas/TicketPostRequest'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketPostRequest'
+            - $ref: '#/components/schemas/TicketObject'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/old.yaml
+++ b/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_reorder_refs/old.yaml
@@ -1,0 +1,51 @@
+x-generator: NSwag v14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))
+openapi: 3.0.0
+info:
+  title: My Title
+  version: "1.0"
+paths:
+  /api/public/form:
+    post:
+      operationId: PostTicket
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              nullable: false
+              oneOf:
+                - $ref: '#/components/schemas/TicketPostRequest'
+                - $ref: '#/components/schemas/TicketObject'
+        required: true
+        x-position: 1
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TicketResponse'
+components:
+  schemas:
+    TicketResponse:
+      type: object
+      properties:
+        ticket:
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/TicketObject'
+            - $ref: '#/components/schemas/TicketPostRequest'
+    TicketObject:
+      type: object
+      properties:
+        allow_attachments:
+          type: boolean
+    TicketPostRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          minLength: 1

--- a/src/Criteo.OpenApi.Comparator/ComparisonRules.cs
+++ b/src/Criteo.OpenApi.Comparator/ComparisonRules.cs
@@ -420,6 +420,18 @@ namespace Criteo.OpenApi.Comparator
             Type = MessageType.Update
         };
 
+
+        /// <summary>
+        /// OpenApi Specification version 3 specific
+        /// </summary>
+        public static ComparisonRule DifferentOneOf = new ComparisonRule
+        {
+            Id = 10321,
+            Code = nameof(DifferentOneOf),
+            Message = "The new version has a different 'oneOf' property than the previous one.",
+            Type = MessageType.Update
+        };
+
         /// <summary>
         /// Rule documentation: https://github.com/Azure/openapi-diff/blob/master/docs/rules/1033.md
         /// </summary>
@@ -587,7 +599,7 @@ namespace Criteo.OpenApi.Comparator
             Message = "The new version is removing a requestBody that was found in the old version.",
             Type = MessageType.Removal
         };
-        
+
         /// <summary>
         /// Rule documentation: https://github.com/Azure/openapi-diff/blob/master/docs/rules/1048.md
         /// </summary>
@@ -598,7 +610,7 @@ namespace Criteo.OpenApi.Comparator
             Message = "The new version is adding a new schema that was not found in the old version.",
             Type = MessageType.Removal
         };
-        
+
         /// <summary>
         /// OpenApi Specification version 3 specific
         /// </summary>


### PR DESCRIPTION
Close #60.

Test case from the reported issue: https://github.com/criteo/openapi-comparator/tree/fix/issue_60/src/Criteo.OpenApi.Comparator.UTest/Resource/oneof_ref_inner_change

Preferred merge strategy: squash